### PR TITLE
Replace '.' with '_' as ResourceHacker struggling to embed.

### DIFF
--- a/Utilizr.WPF/Util/ResourceLoadable.cs
+++ b/Utilizr.WPF/Util/ResourceLoadable.cs
@@ -11,7 +11,7 @@ namespace Utilizr.WPF.Util
         [JsonProperty("_resources")]
         private readonly Dictionary<string, byte[]> _resources;
 
-        public override string EmbeddedResourceName => "RESOURCES.URES";
+        public override string EmbeddedResourceName => "RESOURCES_URES";
 
         public override bool ReadOnly => true;
 

--- a/Utilizr.Win/Util/JsonConfig.cs
+++ b/Utilizr.Win/Util/JsonConfig.cs
@@ -10,7 +10,7 @@ namespace Utilizr.Win.Util;
 public abstract class LoadableEmbedded<T>: Loadable<T> where T : Loadable<T>, new()
 {
     public virtual string? EmbeddedResourceName { get; }
-    
+
     public override string? RawLoad(string customLoadPath = "")
     {
         if (!string.IsNullOrEmpty(EmbeddedResourceName))


### PR DESCRIPTION
Turns out resource hacker can embed correctly, but it means quotes aren't necessary when passed as the `-mask` argument by replacing names containing the `.` char with the `_` char .