### PR TITLE
Optional out parameters on ToByteString() extension method

### DIFF
--- a/Utilizr.Globalisation.Tests/Extensions/ByteConverterTests.cs
+++ b/Utilizr.Globalisation.Tests/Extensions/ByteConverterTests.cs
@@ -27,7 +27,7 @@ namespace Utilizr.Globalisation.Tests.Extensions
         [TestCase(long.MinValue, ExpectedResult = "-8 EB")] 
         public string TestOutput(long size)
         {
-            return ByteConverter.ToBytesString(size, false, 0, false);
+            return ByteConverter.ToBytesString(size, false, out _, out _, 0, false);
         }
     
         [Test]
@@ -35,7 +35,7 @@ namespace Utilizr.Globalisation.Tests.Extensions
         [TestCase(1 << 30, ExpectedResult = "1 GB")]
         public string TestExtensions(long size)
         {
-            return size.ToBytesString(false, 0, true);
+            return size.ToBytesString(false, out _, out _, 0, true);
         }
     }
 }

--- a/Utilizr.Globalisation/Extensions/ByteConverter.cs
+++ b/Utilizr.Globalisation/Extensions/ByteConverter.cs
@@ -34,84 +34,98 @@ namespace Utilizr.Globalisation.Extensions
 
         public static string ToBytesString(this int bytes, int decimalPlaces = 0, bool returnEnglish = false)
         {
-            return ToBytesString((long) bytes, decimalPlaces, returnEnglish);
+            return ToBytesString((long) bytes, out _, out _, decimalPlaces, returnEnglish);
+        }
+
+        public static string ToBytesString(this int bytes, out double byteCount, out string byteUnit, int decimalPlaces = 0, bool returnEnglish = false)
+        {
+            return ToBytesString((long)bytes, out byteCount, out byteUnit, decimalPlaces, returnEnglish);
         }
 
         public static string ToBytesString(this long bytes, int decimalPlaces = 0, bool returnEnglish = false)
         {
+            return ToBytesString(bytes, false, out _, out _, decimalPlaces, returnEnglish);
+        }
+
+        public static string ToBytesString(this long bytes, out double byteCount, out string byteUnit, int decimalPlaces = 0, bool returnEnglish = false)
+        {
             if (Environment.OSVersion.Platform == PlatformID.MacOSX)
-                return ToBytesString(bytes, true, decimalPlaces, returnEnglish);
+                return ToBytesString(bytes, true, out byteCount, out byteUnit, decimalPlaces, returnEnglish);
 
             // unix / windows
-            return ToBytesString(bytes, false, decimalPlaces, returnEnglish);
+            return ToBytesString(bytes, false, out byteCount, out byteUnit, decimalPlaces, returnEnglish);
         }
 
-        public static string ToBytesString(this int bytes, bool useBase10, int decimalPlaces = 0, bool returnEnglish = false)
+        public static string ToBytesString(this int bytes, bool useBase10, out double byteCount, out string byteUnit, int decimalPlaces = 0, bool returnEnglish = false)
         {
-            return ToBytesString((long) bytes, useBase10, decimalPlaces, returnEnglish);
+            return ToBytesString((long) bytes, useBase10, out byteCount, out byteUnit, decimalPlaces, returnEnglish);
         }
 
-        public static string ToBytesString(this long bytes, bool useBase10, int decimalPlaces = 0, bool returnEnglish = false)
+        public static string ToBytesString(this long bytes, bool useBase10, out double byteCount, out string byteUnit, int decimalPlaces = 0, bool returnEnglish = false)
         {
             return useBase10
-                ? Base10Impl(bytes, decimalPlaces, returnEnglish)
-                : Base2Impl(bytes, decimalPlaces, returnEnglish);
+                ? Base10Impl(bytes, decimalPlaces, returnEnglish, out byteCount, out byteUnit)
+                : Base2Impl(bytes, decimalPlaces, returnEnglish, out byteCount, out byteUnit);
         }
 
-        private static string Base2Impl(long bytes, int decimalPlaces, bool returnEnglish)
+        private static string Base2Impl(long bytes, int decimalPlaces, bool returnEnglish, out double byteCount, out string byteUnit)
         {
             string sign = (bytes < 0 ? "-" : "");
             if (bytes == long.MinValue)
                 bytes++;
             bytes = bytes < 0 ? -bytes : bytes;
-            double readable;
-            string suffix;
 
             if (bytes < 0x400) // Byte
             {
-                return string.Format("{0}{1} B", sign, bytes);
+                byteCount = bytes;
+                byteUnit = returnEnglish ? L._M("B") : L._("B");
+                return string.Format("{0}{1:N0} {2}", sign, bytes, byteUnit);
             }
             else if (bytes < KB_THRESHOLD) // Kilobyte
             {
-                suffix = returnEnglish ? L._M("KB") : L._("KB");
-                readable = (double)bytes;
+                byteUnit = returnEnglish ? L._M("KB") : L._("KB");
+                byteCount = (double)bytes;
             }
             else if (bytes < MB_THRESHOLD) // Megabyte
             {
-                suffix = returnEnglish ? L._M("MB") : L._("MB");
-                readable = (double)(bytes >> 10);
+                byteUnit = returnEnglish ? L._M("MB") : L._("MB");
+                byteCount = (double)(bytes >> 10);
             }
             else if (bytes < GB_THRESHOLD) // Gigabyte
             {
-                suffix = returnEnglish ? L._M("GB") : L._("GB");
-                readable = (double)(bytes >> 20);
+                byteUnit = returnEnglish ? L._M("GB") : L._("GB");
+                byteCount = (double)(bytes >> 20);
             }
             else if (bytes < TB_THRESHOLD) // Terabye
             {
-                suffix = returnEnglish ? L._M("TB") : L._("TB");
-                readable = (double)(bytes >> 30);
+                byteUnit = returnEnglish ? L._M("TB") : L._("TB");
+                byteCount = (double)(bytes >> 30);
             }
             else if (bytes < PB_THRESHOLD) // Petabyte
             {
-                suffix = returnEnglish ? L._M("PB") : L._("PB");
-                readable = (double)(bytes >> 40);
+                byteUnit = returnEnglish ? L._M("PB") : L._("PB");
+                byteCount = (double)(bytes >> 40);
             }
             else // Exabyte
             {
-                suffix = returnEnglish ? L._M("EB") : L._("EB");
-                readable = (double)(bytes >> 50);
+                byteUnit = returnEnglish ? L._M("EB") : L._("EB");
+                byteCount = (double)(bytes >> 50);
             }
 
-            readable /= 1024;
+            byteCount /= 1024;
 
             string formatStr = decimalPlaces < 1 ? "0.##" : string.Format("n{0}", decimalPlaces);
-            return string.Format("{0}{1} {2}", sign, readable.ToString(formatStr), suffix);
+            return string.Format("{0}{1} {2}", sign, byteCount.ToString(formatStr), byteUnit);
         }
 
-        private static string Base10Impl(long bytes, int decimalPlaces, bool returnEnglish)
+        private static string Base10Impl(long bytes, int decimalPlaces, bool returnEnglish, out double byteCount, out string byteUnit)
         {
             if (bytes < 1000)
-                return string.Format("{0:N0} {1}", bytes, L._("B"));
+            {
+                byteCount = bytes;
+                byteUnit = returnEnglish ? L._M("B") : L._("B");
+                return string.Format("{0:N0} {1}", byteCount, byteUnit);
+            }
 
             int i = -1;
             while (_base10Thresholds[i+1] < bytes)
@@ -121,11 +135,10 @@ namespace Utilizr.Globalisation.Extensions
                 i++;
             }
 
-            return string.Format(
-                "{0:N" + decimalPlaces + "} {1}",
-                (double)bytes / (double)_base10Thresholds[i],
-                returnEnglish ? _suffix[i] : L._(_suffix[i])
-            );
+            byteCount = (double)bytes / (double)_base10Thresholds[i];
+            byteUnit = returnEnglish ? _suffix[i] : L._(_suffix[i]);
+
+            return string.Format("{0:N" + decimalPlaces + "} {1}", byteCount, byteUnit);
         }
     }
 }


### PR DESCRIPTION
Support the ability to get the number of bytes per unit and the suffix with overloaded extension methods.