### PR TITLE
Fixed generate po files option in Utilizr.Console

### DIFF
--- a/Utilizr.Console/Commands/GeneratePotFile.cs
+++ b/Utilizr.Console/Commands/GeneratePotFile.cs
@@ -14,10 +14,10 @@ namespace Utilizr.Console.Commands
     [Verb("gen-pot", HelpText = "Create a POT file by recursively scanning a src directory for gettext methods.")]
     class GeneratePotFileOptions
     {
-        [Option(SetName = "src", Required = true, HelpText = "The source root directory.")]
+        [Option(Required = true, HelpText = "The source root directory.")]
         public string? SourceDirectory { get; set; }
 
-        [Option(SetName = "out", Required = true, HelpText = "The filename for the output POT file.")]
+        [Option(Required = true, HelpText = "The filename for the output POT file.")]
         public string? Output { get; set; }
     }
 }


### PR DESCRIPTION
Previously `--output` and `--sourcedirectory` were mutually exclusive!