### PR TITLE
Create RegionInfo objects with CultureInfo.Name

### DIFF
--- a/Utilizr.Globalisation/Extensions/NumberExtensions.cs
+++ b/Utilizr.Globalisation/Extensions/NumberExtensions.cs
@@ -97,7 +97,7 @@ namespace Utilizr.Globalisation.Extensions
             try
             {
                 _isoCurrenciesToACultureMap ??= CultureInfo.GetCultures(CultureTypes.SpecificCultures)
-                        .Select(c => new { c, new RegionInfo(c.LCID).ISOCurrencySymbol })
+                        .Select(c => new { c, new RegionInfo(c.Name).ISOCurrencySymbol })
                         .GroupBy(x => x.ISOCurrencySymbol)
                         .ToDictionary(g => g.Key, g => g.First().c, StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
.NET must have changed at some point, doesn't like LCID any more.