### PR TITLE
Fixed .WrapAsTranslatable() extension method

### DIFF
--- a/Utilizr.Globalisation/L.cs
+++ b/Utilizr.Globalisation/L.cs
@@ -467,7 +467,7 @@ namespace Utilizr.Globalisation
         /// <param name="text">Text.</param>
         public static ITranslatable WrapAsTranslatable(this string text)
         {
-            return L._I("{0}", () => L.Args(text));
+            return new MS(text, null);
         }
 
         /// <summary>


### PR DESCRIPTION
Implementation will no longer cause `{0}` to be picked up as a string to translate.