### PR TITLE
SecurityEntity improvements.

### DIFF
--- a/Utilizr.Win/Security/Security.cs
+++ b/Utilizr.Win/Security/Security.cs
@@ -73,7 +73,7 @@ namespace Utilizr.Win.Security
                 if (Advapi32.OpenProcessToken(hProcess, uPriv, ref hToken) == 0)
                     return false;
 
-                return (Advapi32.LookupPrivilegeValue(null, SePrivilegeNames.SE_TCB_NAME, ref tLuid));
+                return (Advapi32.LookupPrivilegeValue(null, SePrivileges.GetSecurityEntityValue(SecurityEntity.SE_TCB_NAME), ref tLuid));
             }
             finally
             {
@@ -166,7 +166,7 @@ namespace Utilizr.Win.Security
             var tLuid = new LUID();
             var newState = new TOKEN_PRIVILEGES();
 
-            if (!Advapi32.LookupPrivilegeValue(null, SePrivilegeNames.SE_RELABEL_NAME, ref tLuid))
+            if (!Advapi32.LookupPrivilegeValue(null, SePrivileges.GetSecurityEntityValue(SecurityEntity.SE_RELABEL_NAME), ref tLuid))
             {
                 Kernel32.CloseHandle(primaryToken);
                 return IntPtr.Zero;

--- a/Utilizr.Win32/Advapi32/Flags/SePrivileges.cs
+++ b/Utilizr.Win32/Advapi32/Flags/SePrivileges.cs
@@ -2,47 +2,91 @@
 
 namespace Utilizr.Win32.Advapi32.Flags
 {
+    public enum SecurityEntity
+    {
+        SE_CREATE_TOKEN_NAME,
+        SE_ASSIGNPRIMARYTOKEN_NAME,
+        SE_LOCK_MEMORY_NAME,
+        SE_INCREASE_QUOTA_NAME,
+        SE_UNSOLICITED_INPUT_NAME,
+        SE_MACHINE_ACCOUNT_NAME,
+        SE_TCB_NAME,
+        SE_SECURITY_NAME,
+        SE_TAKE_OWNERSHIP_NAME,
+        SE_LOAD_DRIVER_NAME,
+        SE_SYSTEM_PROFILE_NAME,
+        SE_SYSTEMTIME_NAME,
+        SE_PROF_SINGLE_PROCESS_NAME,
+        SE_INC_BASE_PRIORITY_NAME,
+        SE_CREATE_PAGEFILE_NAME,
+        SE_CREATE_PERMANENT_NAME,
+        SE_BACKUP_NAME,
+        SE_RESTORE_NAME,
+        SE_SHUTDOWN_NAME,
+        SE_DEBUG_NAME,
+        SE_AUDIT_NAME,
+        SE_SYSTEM_ENVIRONMENT_NAME,
+        SE_CHANGE_NOTIFY_NAME,
+        SE_REMOTE_SHUTDOWN_NAME,
+        SE_UNDOCK_NAME,
+        SE_SYNC_AGENT_NAME,
+        SE_ENABLE_DELEGATION_NAME,
+        SE_MANAGE_VOLUME_NAME,
+        SE_IMPERSONATE_NAME,
+        SE_CREATE_GLOBAL_NAME,
+        SE_CREATE_SYMBOLIC_LINK_NAME,
+        SE_INC_WORKING_SET_NAME,
+        SE_RELABEL_NAME,
+        SE_TIME_ZONE_NAME,
+        SE_TRUSTED_CREDMAN_ACCESS_NAME
+    }
+
     public static class SePrivileges
     {
         public const int SE_PRIVILEGE_ENABLED = 0x00000002;
-    }
+        public const int ERROR_NOT_ALL_ASSIGNED = 1300;
 
-    public static class SePrivilegeNames
-    {
-        public const string SE_ASSIGNPRIMARYTOKEN_NAME = "SeAssignPrimaryTokenPrivilege";
-        public const string SE_AUDIT_NAME = "SeAuditPrivilege";
-        public const string SE_BACKUP_NAME = "SeBackupPrivilege";
-        public const string SE_CHANGE_NOTIFY_NAME = "SeChangeNotifyPrivilege";
-        public const string SE_CREATE_GLOBAL_NAME = "SeCreateGlobalPrivilege";
-        public const string SE_CREATE_PAGEFILE_NAME = "SeCreatePagefilePrivilege";
-        public const string SE_CREATE_PERMANENT_NAME = "SeCreatePermanentPrivilege";
-        public const string SE_CREATE_SYMBOLIC_LINK_NAME = "SeCreateSymbolicLinkPrivilege";
-        public const string SE_CREATE_TOKEN_NAME = "SeCreateTokenPrivilege";
-        public const string SE_DEBUG_NAME = "SeDebugPrivilege";
-        public const string SE_ENABLE_DELEGATION_NAME = "SeEnableDelegationPrivilege";
-        public const string SE_IMPERSONATE_NAME = "SeImpersonatePrivilege";
-        public const string SE_INC_BASE_PRIORITY_NAME = "SeIncreaseBasePriorityPrivilege";
-        public const string SE_INCREASE_QUOTA_NAME = "SeIncreaseQuotaPrivilege";
-        public const string SE_INC_WORKING_SET_NAME = "SeIncreaseWorkingSetPrivilege";
-        public const string SE_LOAD_DRIVER_NAME = "SeLoadDriverPrivilege";
-        public const string SE_LOCK_MEMORY_NAME = "SeLockMemoryPrivilege";
-        public const string SE_MACHINE_ACCOUNT_NAME = "SeMachineAccountPrivilege";
-        public const string SE_MANAGE_VOLUME_NAME = "SeManageVolumePrivilege";
-        public const string SE_PROF_SINGLE_PROCESS_NAME = "SeProfileSingleProcessPrivilege";
-        public const string SE_RELABEL_NAME = "SeRelabelPrivilege";
-        public const string SE_REMOTE_SHUTDOWN_NAME = "SeRelabelPrivilege";
-        public const string SE_RESTORE_NAME = "SeRestorePrivilege";
-        public const string SE_SECURITY_NAME = "SeRestorePrivilege";
-        public const string SE_SHUTDOWN_NAME = "SeShutdownPrivilege";
-        public const string SE_SYNC_AGENT_NAME = "SeSyncAgentPrivilege";
-        public const string SE_SYSTEM_ENVIRONMENT_NAME = "SeSystemEnvironmentPrivilege";
-        public const string SE_SYSTEM_PROFILE_NAME = "SeSystemProfilePrivilege";
-        public const string SE_SYSTEMTIME_NAME = "SeSystemtimePrivilege";
-        public const string SE_TAKE_OWNERSHIP_NAME = "SeTakeOwnershipPrivilege";
-        public const string SE_TCB_NAME = "SeTcbPrivilege";
-        public const string SE_TIME_ZONE_NAME = "SeTimeZonePrivilege";
-        public const string SE_TRUSTED_CREDMAN_ACCESS_NAME = "SeTrustedCredManAccessPrivilege";
-        public const string SE_UNDOCK_NAME = "SeUndockPrivilege";
-        public const string SE_UNSOLICITED_INPUT_NAME = "SeUnsolicitedInputPrivilege";
+        public static string GetSecurityEntityValue(SecurityEntity securityEntity)
+        {
+            return securityEntity switch
+            {
+                SecurityEntity.SE_ASSIGNPRIMARYTOKEN_NAME => "SeAssignPrimaryTokenPrivilege",
+                SecurityEntity.SE_AUDIT_NAME => "SeAuditPrivilege",
+                SecurityEntity.SE_BACKUP_NAME => "SeBackupPrivilege",
+                SecurityEntity.SE_CHANGE_NOTIFY_NAME => "SeChangeNotifyPrivilege",
+                SecurityEntity.SE_CREATE_GLOBAL_NAME => "SeCreateGlobalPrivilege",
+                SecurityEntity.SE_CREATE_PAGEFILE_NAME => "SeCreatePagefilePrivilege",
+                SecurityEntity.SE_CREATE_PERMANENT_NAME => "SeCreatePermanentPrivilege",
+                SecurityEntity.SE_CREATE_SYMBOLIC_LINK_NAME => "SeCreateSymbolicLinkPrivilege",
+                SecurityEntity.SE_CREATE_TOKEN_NAME => "SeCreateTokenPrivilege",
+                SecurityEntity.SE_DEBUG_NAME => "SeDebugPrivilege",
+                SecurityEntity.SE_ENABLE_DELEGATION_NAME => "SeEnableDelegationPrivilege",
+                SecurityEntity.SE_IMPERSONATE_NAME => "SeImpersonatePrivilege",
+                SecurityEntity.SE_INC_BASE_PRIORITY_NAME => "SeIncreaseBasePriorityPrivilege",
+                SecurityEntity.SE_INCREASE_QUOTA_NAME => "SeIncreaseQuotaPrivilege",
+                SecurityEntity.SE_INC_WORKING_SET_NAME => "SeIncreaseWorkingSetPrivilege",
+                SecurityEntity.SE_LOAD_DRIVER_NAME => "SeLoadDriverPrivilege",
+                SecurityEntity.SE_LOCK_MEMORY_NAME => "SeLockMemoryPrivilege",
+                SecurityEntity.SE_MACHINE_ACCOUNT_NAME => "SeMachineAccountPrivilege",
+                SecurityEntity.SE_MANAGE_VOLUME_NAME => "SeManageVolumePrivilege",
+                SecurityEntity.SE_PROF_SINGLE_PROCESS_NAME => "SeProfileSingleProcessPrivilege",
+                SecurityEntity.SE_RELABEL_NAME => "SeRelabelPrivilege",
+                SecurityEntity.SE_REMOTE_SHUTDOWN_NAME => "SeRemoteShutdownPrivilege",
+                SecurityEntity.SE_RESTORE_NAME => "SeRestorePrivilege",
+                SecurityEntity.SE_SECURITY_NAME => "SeSecurityPrivilege",
+                SecurityEntity.SE_SHUTDOWN_NAME => "SeShutdownPrivilege",
+                SecurityEntity.SE_SYNC_AGENT_NAME => "SeSyncAgentPrivilege",
+                SecurityEntity.SE_SYSTEM_ENVIRONMENT_NAME => "SeSystemEnvironmentPrivilege",
+                SecurityEntity.SE_SYSTEM_PROFILE_NAME => "SeSystemProfilePrivilege",
+                SecurityEntity.SE_SYSTEMTIME_NAME => "SeSystemtimePrivilege",
+                SecurityEntity.SE_TAKE_OWNERSHIP_NAME => "SeTakeOwnershipPrivilege",
+                SecurityEntity.SE_TCB_NAME => "SeTcbPrivilege",
+                SecurityEntity.SE_TIME_ZONE_NAME => "SeTimeZonePrivilege",
+                SecurityEntity.SE_TRUSTED_CREDMAN_ACCESS_NAME => "SeTrustedCredManAccessPrivilege",
+                SecurityEntity.SE_UNDOCK_NAME => "SeUndockPrivilege",
+                SecurityEntity.SE_UNSOLICITED_INPUT_NAME => "SeUnsolicitedInputPrivilege",
+                _ => throw new ArgumentOutOfRangeException(typeof(SecurityEntity).Name),
+            };
+        }
     }
 }


### PR DESCRIPTION
Use enums instead of consts for the security entities when adjusting privileges.