### PR TITLE
Target net8.0 and net7.0

### DIFF
--- a/Utilizr.Console/Properties/launchSettings.json
+++ b/Utilizr.Console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Utilizr.Console": {
       "commandName": "Project",
-      "commandLineArgs": "flatten-dictionary --assemblypath \"..\\..\\..\\..\\..\\SecuritySuite\\GUI.Theme\\bin\\Debug\\net7.0-windows\\GUI.Theme.dll\" --dictionarypath LightTheme.xaml --output ./test.xaml"
+      "commandLineArgs": "flatten-dictionary --assemblypath \"..\\..\\..\\..\\..\\SecuritySuite\\GUI.Theme\\bin\\Debug\\net8.0-windows\\GUI.Theme.dll\" --dictionarypath LightTheme.xaml --output ./test.xaml"
     }
   }
 }

--- a/Utilizr.Console/Properties/launchSettings.json
+++ b/Utilizr.Console/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "Utilizr.Console": {
-      "commandName": "Project",
-      "commandLineArgs": "flatten-dictionary --assemblypath \"..\\..\\..\\..\\..\\SecuritySuite\\GUI.Theme\\bin\\Debug\\net8.0-windows\\GUI.Theme.dll\" --dictionarypath LightTheme.xaml --output ./test.xaml"
-    }
-  }
-}

--- a/Utilizr.Console/Utilizr.Console.csproj
+++ b/Utilizr.Console/Utilizr.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+     <TargetFrameworks>net7.0-windows;net8.0-windows</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/Utilizr.Console/Utilizr.Console.csproj
+++ b/Utilizr.Console/Utilizr.Console.csproj
@@ -17,8 +17,4 @@
     <ProjectReference Include="..\Utilizr.WPF\Utilizr.WPF.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-
 </Project>

--- a/Utilizr.Console/Utilizr.Console.csproj
+++ b/Utilizr.Console/Utilizr.Console.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="..\Utilizr.WPF\Utilizr.WPF.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
 </Project>

--- a/Utilizr.Globalisation.Tests/Utilizr.Globalisation.Tests.csproj
+++ b/Utilizr.Globalisation.Tests/Utilizr.Globalisation.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/Utilizr.Logging.Tests/Utilizr.Logging.Tests.csproj
+++ b/Utilizr.Logging.Tests/Utilizr.Logging.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/Utilizr.Tests/Utilizr.Tests.csproj
+++ b/Utilizr.Tests/Utilizr.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         <ImplicitUsings>false</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/Utilizr.Vpn.Ras/Utilizr.Vpn.Ras.csproj
+++ b/Utilizr.Vpn.Ras/Utilizr.Vpn.Ras.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFrameworks>net7.0-windows;net8.0-windows</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/Utilizr.Vpn/Utilizr.Vpn.csproj
+++ b/Utilizr.Vpn/Utilizr.Vpn.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFrameworks>net7.0-windows;net8.0-windows</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/Utilizr.WPF/Utilizr.WPF.csproj
+++ b/Utilizr.WPF/Utilizr.WPF.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFrameworks>net7.0-windows;net8.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <LangVersion>latest</LangVersion>

--- a/Utilizr.Win.Tests/Utilizr.Win.Tests.csproj
+++ b/Utilizr.Win.Tests/Utilizr.Win.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFrameworks>net7.0-windows;net8.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/Utilizr.Win.TrayIcon/Utilizr.Win.TrayIcon.csproj
+++ b/Utilizr.Win.TrayIcon/Utilizr.Win.TrayIcon.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFrameworks>net7.0-windows;net8.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/Utilizr.Win/Utilizr.Win.csproj
+++ b/Utilizr.Win/Utilizr.Win.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFrameworks>net7.0-windows;net8.0-windows</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/Utilizr.Win32/Utilizr.Win32.csproj
+++ b/Utilizr.Win32/Utilizr.Win32.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFrameworks>net7.0-windows;net8.0-windows</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>

--- a/Utilizr/Utilizr.csproj
+++ b/Utilizr/Utilizr.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>


### PR DESCRIPTION
Updated all projects to also target `net8.0` since dotnet 7 is reaching EOL in May 2024.

Keep the `net7.0` target for now to avoid breaking other consumers.