### PR TITLE
Fix CopyDirectoryContents()

### DIFF
--- a/Utilizr/FileSystem/DirectoryHelper.cs
+++ b/Utilizr/FileSystem/DirectoryHelper.cs
@@ -112,13 +112,13 @@ namespace Utilizr.FileSystem
         /// <param name="onlyCopyIfAlreadyExists">If set to <c>true</c> only copy if already exists.</param>
         /// <param name="recursive">If set to <c>true</c> recursive.</param>
         /// <param name="ignoreFolderNames">Ignore folder names.</param>
-        /// <param name="ignoreFileExtensions">File without a matching extension will not be copied.</param>
+        /// <param name="ignoreFileExtensions">File with a matching extension will not be copied.</param>
         public static void CopyDirectoryContents(
             string sourceDirectory,
             string destinationDirectory,
             bool onlyCopyIfAlreadyExists,
             bool recursive,
-            string[] ignoreFolderNames,
+            string[]? ignoreFolderNames,
             string[]? ignoreFileExtensions)
         {
             if (!Directory.Exists(destinationDirectory))
@@ -127,7 +127,7 @@ namespace Utilizr.FileSystem
             foreach (var file in Directory.GetFiles(sourceDirectory))
             {
                 var fileExt = file.ToLower();
-                if (fileExt.EndsWith(".ds_store") || ignoreFileExtensions?.Any(p => p.Equals(fileExt, StringComparison.OrdinalIgnoreCase)) == true)
+                if (fileExt.EndsWith(".ds_store") || ignoreFileExtensions?.Any(p => p.EndsWith(fileExt, StringComparison.OrdinalIgnoreCase)) == true)
                     continue;
 
                 var destinationFile = Path.Combine(destinationDirectory, Path.GetFileName(file));

--- a/Utilizr/FileSystem/DirectoryHelper.cs
+++ b/Utilizr/FileSystem/DirectoryHelper.cs
@@ -126,8 +126,8 @@ namespace Utilizr.FileSystem
 
             foreach (var file in Directory.GetFiles(sourceDirectory))
             {
-                var fileExt = file.ToLower();
-                if (fileExt.EndsWith(".ds_store") || ignoreFileExtensions?.Any(p => p.EndsWith(fileExt, StringComparison.OrdinalIgnoreCase)) == true)
+                var fileWithExt = file.ToLower();
+                if (fileWithExt.EndsWith(".ds_store") || ignoreFileExtensions?.Any(p => fileWithExt.EndsWith(p, StringComparison.OrdinalIgnoreCase)) == true)
                     continue;
 
                 var destinationFile = Path.Combine(destinationDirectory, Path.GetFileName(file));


### PR DESCRIPTION
- Fixed parameter documentation.
- Fixed implementation so it does exclude the specified extensions.
- Fixed nullable reference type.