### PR TITLE
Themed imgages

### DIFF
--- a/Utilizr.WPF/Converters/UriToImageFallbackConverter.cs
+++ b/Utilizr.WPF/Converters/UriToImageFallbackConverter.cs
@@ -1,12 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Data;
-using System.Windows.Markup;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Utilizr.WPF.Util;
 

--- a/Utilizr.WPF/Converters/UriToImageThemedConverter.cs
+++ b/Utilizr.WPF/Converters/UriToImageThemedConverter.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Windows.Data;
 using System.Windows.Markup;
+using Utilizr.Logging;
 using Utilizr.WPF.Util;
 
 namespace Utilizr.WPF.Converters
@@ -41,11 +42,14 @@ namespace Utilizr.WPF.Converters
             if (parameter is ImageThemedConverterMode explicitMode)
                 mode = explicitMode;
 
-            return ResourceHelper.GetImageSource(
+            var result = ResourceHelper.GetImageSource(
                 (string)value!,
                 CurrentTheme,
                 mode == ImageThemedConverterMode.FallbackToUnthemedResource
             );
+
+            Log.Debug(nameof(UriToImageThemedConverter), $"CurrentTheme={CurrentTheme}, value={value}, mode={mode}, result={result}");
+            return result;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/Utilizr.WPF/Converters/UriToImageThemedConverter.cs
+++ b/Utilizr.WPF/Converters/UriToImageThemedConverter.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Markup;
+using Utilizr.WPF.Util;
+
+namespace Utilizr.WPF.Converters
+{
+    public enum ImageThemedConverterMode
+    {
+        /// <summary>
+        /// Only check the themed folder.
+        /// </summary>
+        ThemedResourceOnly,
+
+        /// <summary>
+        /// The main use case here is to make it easier to implement UserControls without the need to
+        /// swap out to different IValueConverter implementations for themed and unthemed icons.
+        /// </summary>
+        FallbackToUnthemedResource,
+    }
+
+    public class UriToImageThemedConverter: MarkupExtension, IValueConverter
+    {
+        private static UriToImageThemedConverter? _instance;
+
+        /// <summary>
+        /// The subfolder which will be checked when trying to load a theme specific image.
+        /// </summary>
+        public static string? CurrentTheme { get; set; }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            _instance ??= new UriToImageThemedConverter();
+            return _instance;
+        }
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var mode = ImageThemedConverterMode.FallbackToUnthemedResource;
+            if (parameter is ImageThemedConverterMode explicitMode)
+                mode = explicitMode;
+
+            return ResourceHelper.GetImageSource(
+                (string)value!,
+                CurrentTheme,
+                mode == ImageThemedConverterMode.FallbackToUnthemedResource
+            );
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Utilizr.WPF/Dictionary/Converters.xaml
+++ b/Utilizr.WPF/Dictionary/Converters.xaml
@@ -38,5 +38,6 @@
     <converters:UriToImageConverter x:Key="UriToImageConverter"/>
     <converters:UriToIconConverter x:Key="UriToIconConverter"/>
     <converters:UriToImageFallbackConverter x:Key="UriToImageFallbackConverter"/>
+    <converters:UriToImageThemedConverter x:Key="UriToImageThemedConverter"/>
     <converters:ValueConverterGroup x:Key="ValueConverterGroup"/>
 </ResourceDictionary>

--- a/Utilizr.WPF/Util/ImageCache.cs
+++ b/Utilizr.WPF/Util/ImageCache.cs
@@ -23,13 +23,13 @@ namespace Utilizr.WPF.Util
         {
             var themedResource = string.IsNullOrEmpty(theme)
                 ? resource
-                : Path.Combine(theme, resource);
+                : $"{theme}\\{resource}";
 
             BitmapFrame? result;
-            if (_cache.TryGetValue(resource, out result))
+            if (_cache.TryGetValue(themedResource, out result))
                 return result;
 
-            var data = ResourceLoadable.Instance?.Get(resource);
+            var data = ResourceLoadable.Instance?.Get(themedResource);
             if (data != null)
             {
                 using (var memStream = new MemoryStream(data))
@@ -38,7 +38,7 @@ namespace Utilizr.WPF.Util
                 }
                 lock (LOCK)
                 {
-                    _cache[resource] = result;
+                    _cache[themedResource] = result;
                 }
             }
 

--- a/Utilizr.WPF/Util/ImageCache.cs
+++ b/Utilizr.WPF/Util/ImageCache.cs
@@ -19,8 +19,12 @@ namespace Utilizr.WPF.Util
             _cacheSvg = new Dictionary<string, string>();
         }
 
-        internal static BitmapFrame? Get(string resource)
+        internal static BitmapFrame? Get(string resource, string? theme = null)
         {
+            var themedResource = string.IsNullOrEmpty(theme)
+                ? resource
+                : Path.Combine(theme, resource);
+
             BitmapFrame? result;
             if (_cache.TryGetValue(resource, out result))
                 return result;

--- a/Utilizr.WPF/Util/ImageCache.cs
+++ b/Utilizr.WPF/Util/ImageCache.cs
@@ -23,7 +23,7 @@ namespace Utilizr.WPF.Util
         {
             var themedResource = string.IsNullOrEmpty(theme)
                 ? resource
-                : $"{theme}\\{resource}";
+                : $"{theme}/{resource}";
 
             BitmapFrame? result;
             if (_cache.TryGetValue(themedResource, out result))

--- a/Utilizr.WPF/Util/ResourceHelper.cs
+++ b/Utilizr.WPF/Util/ResourceHelper.cs
@@ -41,6 +41,8 @@ namespace Utilizr.WPF.Util
                 ? new Uri($"../../{_resourceDir}/{potentialThemeWithTrialingSlash}{resourceKey}", UriKind.Relative)
                 : new Uri($"pack://siteoforigin:,,,/{_resourceDir}/{potentialThemeWithTrialingSlash}{resourceKey}");
 
+            Log.Debug(nameof(ResourceHelper), $"Returning URI '{uri}' for resource = {resourceKey} and theme = {theme}");
+
             return uri;
         }
 
@@ -57,7 +59,7 @@ namespace Utilizr.WPF.Util
             {
                 CheckDesignMode();
 
-                var bitmapFrame = ImageCache.Get(resourceKey);
+                var bitmapFrame = ImageCache.Get(resourceKey, theme);
                 if (bitmapFrame != null)
                     return bitmapFrame;
 
@@ -72,7 +74,7 @@ namespace Utilizr.WPF.Util
                 if (!string.IsNullOrEmpty(theme) && fallbackToUnthemed)
                     return GetImageSource(resourceKey);
 
-                Log.Exception(ex, $"Failed to load resource for key {resourceKey}");
+                Log.Exception(ex, $"Failed to load resource for key {resourceKey}, theme={theme ?? "none"}");
 #if DEBUG
                 if (_inDesignMode != true)
                     throw;

--- a/Utilizr.WPF/Util/ResourceHelper.cs
+++ b/Utilizr.WPF/Util/ResourceHelper.cs
@@ -51,7 +51,7 @@ namespace Utilizr.WPF.Util
         /// <param name="resourceKey">Image name including extension, e.g. foobar.png</param>
         /// <param name="theme">Provider an optional theme name. This subfolder of the resources folder will be checked.</param>
         /// <returns></returns>
-        public static BitmapFrame? GetImageSource(string resourceKey, string? theme = null)
+        public static BitmapFrame? GetImageSource(string resourceKey, string? theme = null, bool fallbackToUnthemed = false)
         {
             try
             {
@@ -69,6 +69,9 @@ namespace Utilizr.WPF.Util
             }
             catch (Exception ex)
             {
+                if (!string.IsNullOrEmpty(theme) && fallbackToUnthemed)
+                    return GetImageSource(resourceKey);
+
                 Log.Exception(ex, $"Failed to load resource for key {resourceKey}");
 #if DEBUG
                 if (_inDesignMode != true)

--- a/Utilizr.WPF/Util/ResourceHelper.cs
+++ b/Utilizr.WPF/Util/ResourceHelper.cs
@@ -20,20 +20,26 @@ namespace Utilizr.WPF.Util
             set => _resourceDir = value.Trim().Trim('/');
         }
 
+
         private static bool? _inDesignMode;
 
         /// <summary>
         /// Returns the URI for the specified resourceKey
         /// </summary>
         /// <param name="resourceKey">Image name including extension, e.g. foobar.png</param>
+        /// <param name="theme">Provide an optional theme name. The return URI will include this subfolder from <see cref="ResourceDir"/>.</param>
         /// <returns></returns>
-        public static Uri GetImageUri(string resourceKey)
+        public static Uri GetImageUri(string resourceKey, string? theme = null)
         {
             CheckDesignMode();
 
+            var potentialThemeWithTrialingSlash = string.Empty;
+            if (!string.IsNullOrEmpty(theme))
+                potentialThemeWithTrialingSlash = $"{theme.Trim('/')}/";
+
             Uri uri = _inDesignMode == true // Nullable bool
-                ? new Uri($"../../{_resourceDir}/{resourceKey}", UriKind.Relative)
-                : new Uri($"pack://siteoforigin:,,,/{_resourceDir}/{resourceKey}");
+                ? new Uri($"../../{_resourceDir}/{potentialThemeWithTrialingSlash}{resourceKey}", UriKind.Relative)
+                : new Uri($"pack://siteoforigin:,,,/{_resourceDir}/{potentialThemeWithTrialingSlash}{resourceKey}");
 
             return uri;
         }
@@ -43,8 +49,9 @@ namespace Utilizr.WPF.Util
         /// Get an image from the resources folder
         /// </summary>
         /// <param name="resourceKey">Image name including extension, e.g. foobar.png</param>
+        /// <param name="theme">Provider an optional theme name. This subfolder of the resources folder will be checked.</param>
         /// <returns></returns>
-        public static BitmapFrame? GetImageSource(string resourceKey)
+        public static BitmapFrame? GetImageSource(string resourceKey, string? theme = null)
         {
             try
             {
@@ -54,7 +61,7 @@ namespace Utilizr.WPF.Util
                 if (bitmapFrame != null)
                     return bitmapFrame;
 
-                var uri = GetImageUri(resourceKey);
+                var uri = GetImageUri(resourceKey, theme);
 
                 //IMPORTANT!!! never return a BitmapImage.. doing so will lock image files and prevent application auto updates from working.
                 return BitmapFrame.Create(uri, BitmapCreateOptions.None, BitmapCacheOption.OnLoad);

--- a/Utilizr.WPF/Util/ResourceHelper.cs
+++ b/Utilizr.WPF/Util/ResourceHelper.cs
@@ -27,7 +27,7 @@ namespace Utilizr.WPF.Util
         /// Returns the URI for the specified resourceKey
         /// </summary>
         /// <param name="resourceKey">Image name including extension, e.g. foobar.png</param>
-        /// <param name="theme">Provide an optional theme name. The return URI will include this subfolder from <see cref="ResourceDir"/>.</param>
+        /// <param name="theme">Provide an optional theme name. The returned URI will include this subfolder from <see cref="ResourceDir"/>.</param>
         /// <returns></returns>
         public static Uri GetImageUri(string resourceKey, string? theme = null)
         {
@@ -41,7 +41,7 @@ namespace Utilizr.WPF.Util
                 ? new Uri($"../../{_resourceDir}/{potentialThemeWithTrialingSlash}{resourceKey}", UriKind.Relative)
                 : new Uri($"pack://siteoforigin:,,,/{_resourceDir}/{potentialThemeWithTrialingSlash}{resourceKey}");
 
-            Log.Debug(nameof(ResourceHelper), $"Returning URI '{uri}' for resource = {resourceKey} and theme = {theme}");
+            Log.Debug(nameof(ResourceHelper), $"Returning URI '{uri}' for resource='{resourceKey}' and theme='{theme}'");
 
             return uri;
         }


### PR DESCRIPTION
Theme support for images where different .pngs have to be provided to support different colour schemes.

- `ResourceHelper` updated for optional `theme` parameters to look in a subfolder of the configured `ResourceDir`.
- Added a `UriToImageThemedConverter` `IvalueConverter` with a static `CurrentTheme` property.
    - Allows setting a `ConverterParameter` of `ImageThemedConverterMode` to either only load the image from the theme folder, or allow falling back to the `ResourceDir`. Makes it easier to create custom `UserControls` where not all images will be themed rather than swap out the `IValueConverter`s.
- An optional `CopyDirectoryCustomFilterDelegate` parameter on `DirectoryHelper.CopyDirectoryContents()` to allow more specific file and folder filtering. 