### PR TITLE
IconExtractor.GetIcon() now checks for paths which include the icon index.

### DIFF
--- a/Utilizr.WPF/Util/IconExtractor.cs
+++ b/Utilizr.WPF/Util/IconExtractor.cs
@@ -83,7 +83,12 @@ namespace Utilizr.WPF.Util
                 if (string.IsNullOrEmpty(path))
                     return backupIcon();
 
-                var icon = Icon.ExtractAssociatedIcon(path);
+                var iconIndex = path.IndexOf(',');
+                var safePath = iconIndex > 0
+                    ? path.Substring(0, iconIndex)
+                    : path;
+
+                var icon = Icon.ExtractAssociatedIcon(safePath);
                 if (icon == null)
                     return backupIcon();
 


### PR DESCRIPTION
Handle scenarios where `',0'` is added to the path.

We cannot pass in this value, `System.Drawing.Common.Icon.ExtractAssociatedIcon()` doesn't expose the index, hardcoded to a private method with index 0:

```
public static Icon? ExtractAssociatedIcon(string filePath) => ExtractAssociatedIcon(filePath, 0);

private static unsafe Icon? ExtractAssociatedIcon(string filePath, int index)
{
    ...
```