### PR TITLE
DotNetZip replacement CVE

### DIFF
--- a/Utilizr.Logging/Handlers/RotatingFileHandler.cs
+++ b/Utilizr.Logging/Handlers/RotatingFileHandler.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Text;
 using System.Threading.Tasks;
+using Utilizr.Logging.Filters;
 //using Utilizr.Extensions;
 
 namespace Utilizr.Logging.Handlers
@@ -107,18 +108,14 @@ namespace Utilizr.Logging.Handlers
             {
                 try
                 {
-                    var zip = ZipFile.Open($"{filePath}{zipExt}", ZipArchiveMode.Create, Encoding.UTF8);
-                    zip.CreateEntryFromFile(filePath, Path.GetFileName(filePath), CompressionLevel.Optimal);
-                    zip.Dispose();
-
-                    //using (var zip = new ZipFile($"{filePath}{zipExt}"))
-                    //{
-                    //    zip.AlternateEncoding = Encoding.UTF8;
-                    //    zip.AlternateEncodingUsage = ZipOption.AsNecessary;
-
-                    //    zip.AddFile(filePath, string.Empty);
-                    //    zip.Save();
-                    //}
+                    using (var zipFileSteam = new FileStream($"{filePath}{zipExt}", FileMode.Create, FileAccess.ReadWrite))
+                    using (var zip = new ZipArchive(zipFileSteam, ZipArchiveMode.Create, true))
+                    {
+                        var archiveEntry = zip.CreateEntry(Path.GetFileName(filePath));
+                        using var archiveStream = archiveEntry.Open();
+                        using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                        fs.CopyTo(archiveStream);
+                    }
 
                     File.Delete(filePath);
                 }

--- a/Utilizr.Logging/Handlers/RotatingFileHandler.cs
+++ b/Utilizr.Logging/Handlers/RotatingFileHandler.cs
@@ -1,6 +1,6 @@
-﻿using Ionic.Zip;
-using System;
+﻿using System;
 using System.IO;
+using System.IO.Compression;
 using System.Text;
 using System.Threading.Tasks;
 //using Utilizr.Extensions;
@@ -107,14 +107,18 @@ namespace Utilizr.Logging.Handlers
             {
                 try
                 {
-                    using (var zip = new ZipFile($"{filePath}{zipExt}"))
-                    {
-                        zip.AlternateEncoding = Encoding.UTF8;
-                        zip.AlternateEncodingUsage = ZipOption.AsNecessary;
+                    var zip = ZipFile.Open($"{filePath}{zipExt}", ZipArchiveMode.Create, Encoding.UTF8);
+                    zip.CreateEntryFromFile(filePath, Path.GetFileName(filePath), CompressionLevel.Optimal);
+                    zip.Dispose();
 
-                        zip.AddFile(filePath, string.Empty);
-                        zip.Save();
-                    }
+                    //using (var zip = new ZipFile($"{filePath}{zipExt}"))
+                    //{
+                    //    zip.AlternateEncoding = Encoding.UTF8;
+                    //    zip.AlternateEncodingUsage = ZipOption.AsNecessary;
+
+                    //    zip.AddFile(filePath, string.Empty);
+                    //    zip.Save();
+                    //}
 
                     File.Delete(filePath);
                 }

--- a/Utilizr.Logging/Utilizr.Logging.csproj
+++ b/Utilizr.Logging/Utilizr.Logging.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--<PackageReference Include="DotNetZip" Version="1.16.0" />-->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/Utilizr.Logging/Utilizr.Logging.csproj
+++ b/Utilizr.Logging/Utilizr.Logging.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetZip" Version="1.16.0" />
+    <!--<PackageReference Include="DotNetZip" Version="1.16.0" />-->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/Utilizr/Info/AppInfo.cs
+++ b/Utilizr/Info/AppInfo.cs
@@ -1,6 +1,6 @@
-﻿using Ionic.Zip;
-using System;
+﻿using System;
 using System.IO;
+using System.IO.Compression;
 using System.Reflection;
 using System.Text;
 using Utilizr.Extensions;
@@ -209,44 +209,108 @@ namespace Utilizr.Info
                 File.Delete(destinationFile);
             }
 
-            using var zip = new ZipFile(destinationFile);
-            zip.AlternateEncoding = Encoding.UTF8;
-            zip.AlternateEncodingUsage = ZipOption.AsNecessary;
-
-            zip.AddDirectory(LogDirectory, "logs");
-            zip.AddDirectory(DataDirectory, "data");
-
-            foreach (var additionalDir in additionalDirs)
+            using (var fs = new FileStream(destinationFile, FileMode.Create, FileAccess.ReadWrite))
+            using (var zip = new ZipArchive(fs, ZipArchiveMode.Create, true))
             {
-                try
-                {
-                    if (!Directory.Exists(additionalDir.Path))
-                        continue;
+                var enumOptions = new EnumerationOptions() { RecurseSubdirectories = true };
 
-                    zip.AddDirectory(additionalDir.Path, additionalDir.PathInArchive);
-                }
-                catch (Exception ex)
+                void addFolderToZip(ZipLogsAdditionalItem folder)
                 {
-                    System.Diagnostics.Debug.WriteLine($"Error adding additional directory '{additionalDir.Path}' to archive: {ex.Message}");
+                    //var filesToAdd = Directory.EnumerateFiles(folder.Path, "*", enumOptions);
+                    var filesToAdd = Directory.GetFiles(folder.Path, "*", SearchOption.AllDirectories);
+                    foreach (var file in filesToAdd)
+                    {
+                        try
+                        {
+                            // failsafe to remove the start of the path
+                            var relativeToFolderFilePath = file.Substring(folder.Path.Length).TrimStart(Path.DirectorySeparatorChar);
+                            var nameInZip = Path.Combine(folder.PathInArchive, relativeToFolderFilePath);
+                            //zip.CreateEntryFromFile(file, nameInZip);
+
+                            var archiveEntry = zip.CreateEntry(nameInZip);
+                            using var archiveStream = archiveEntry.Open();
+                            using var fs = new FileStream(file, FileMode.Open, FileAccess.Read);
+                            fs.CopyTo(archiveStream);
+                        }
+                        catch (Exception ex)
+                        {
+                            
+                        }
+                    }
+                }
+
+                addFolderToZip(new ZipLogsAdditionalItem { Path = LogDirectory, PathInArchive = "logs" });
+                addFolderToZip(new ZipLogsAdditionalItem { Path = DataDirectory, PathInArchive = "data" });
+
+                foreach (var additionalDirectory in additionalDirs)
+                {
+                    try
+                    {
+                        if (!Directory.Exists(additionalDirectory.Path))
+                            continue;
+
+                        addFolderToZip(additionalDirectory);
+                    }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"Error adding additional directory '{additionalDirectory.Path}' to archive: {ex.Message}");
+                    }
+                }
+
+                foreach (var additionalFile in additionalFiles)
+                {
+                    try
+                    {
+                        if (!File.Exists(additionalFile.Path))
+                            continue;
+
+                        zip.CreateEntryFromFile(additionalFile.Path, additionalFile.PathInArchive);
+                    }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"Error adding additional file '{additionalFile.Path}' to archive: {ex.Message}");
+                    }
                 }
             }
 
-            foreach (var additionalFile in additionalFiles)
-            {
-                try
-                {
-                    if (!File.Exists(additionalFile.Path))
-                        continue;
+            //using var zip = new ZipFile(destinationFile);
+            //zip.AlternateEncoding = Encoding.UTF8;
+            //zip.AlternateEncodingUsage = ZipOption.AsNecessary;
 
-                    zip.AddFile(additionalFile.Path, additionalFile.PathInArchive);
-                }
-                catch (Exception ex)
-                {
-                    System.Diagnostics.Debug.WriteLine($"Error adding additional file '{additionalFile.Path}' to archive: {ex.Message}");
-                }
-            }
+            //zip.AddDirectory(LogDirectory, "logs");
+            //zip.AddDirectory(DataDirectory, "data");
 
-            zip.Save();
+            //foreach (var additionalDir in additionalDirs)
+            //{
+            //    try
+            //    {
+            //        if (!Directory.Exists(additionalDir.Path))
+            //            continue;
+
+            //        zip.AddDirectory(additionalDir.Path, additionalDir.PathInArchive);
+            //    }
+            //    catch (Exception ex)
+            //    {
+            //        System.Diagnostics.Debug.WriteLine($"Error adding additional directory '{additionalDir.Path}' to archive: {ex.Message}");
+            //    }
+            //}
+
+            //foreach (var additionalFile in additionalFiles)
+            //{
+            //    try
+            //    {
+            //        if (!File.Exists(additionalFile.Path))
+            //            continue;
+
+            //        zip.AddFile(additionalFile.Path, additionalFile.PathInArchive);
+            //    }
+            //    catch (Exception ex)
+            //    {
+            //        System.Diagnostics.Debug.WriteLine($"Error adding additional file '{additionalFile.Path}' to archive: {ex.Message}");
+            //    }
+            //}
+
+            //zip.Save();
         }
     }
 

--- a/Utilizr/Info/AppInfo.cs
+++ b/Utilizr/Info/AppInfo.cs
@@ -225,7 +225,6 @@ namespace Utilizr.Info
                             // failsafe to remove the start of the path
                             var relativeToFolderFilePath = file.Substring(folder.Path.Length).TrimStart(Path.DirectorySeparatorChar);
                             var nameInZip = Path.Combine(folder.PathInArchive, relativeToFolderFilePath);
-                            //zip.CreateEntryFromFile(file, nameInZip);
 
                             var archiveEntry = zip.CreateEntry(nameInZip);
                             using var archiveStream = archiveEntry.Open();
@@ -272,45 +271,6 @@ namespace Utilizr.Info
                     }
                 }
             }
-
-            //using var zip = new ZipFile(destinationFile);
-            //zip.AlternateEncoding = Encoding.UTF8;
-            //zip.AlternateEncodingUsage = ZipOption.AsNecessary;
-
-            //zip.AddDirectory(LogDirectory, "logs");
-            //zip.AddDirectory(DataDirectory, "data");
-
-            //foreach (var additionalDir in additionalDirs)
-            //{
-            //    try
-            //    {
-            //        if (!Directory.Exists(additionalDir.Path))
-            //            continue;
-
-            //        zip.AddDirectory(additionalDir.Path, additionalDir.PathInArchive);
-            //    }
-            //    catch (Exception ex)
-            //    {
-            //        System.Diagnostics.Debug.WriteLine($"Error adding additional directory '{additionalDir.Path}' to archive: {ex.Message}");
-            //    }
-            //}
-
-            //foreach (var additionalFile in additionalFiles)
-            //{
-            //    try
-            //    {
-            //        if (!File.Exists(additionalFile.Path))
-            //            continue;
-
-            //        zip.AddFile(additionalFile.Path, additionalFile.PathInArchive);
-            //    }
-            //    catch (Exception ex)
-            //    {
-            //        System.Diagnostics.Debug.WriteLine($"Error adding additional file '{additionalFile.Path}' to archive: {ex.Message}");
-            //    }
-            //}
-
-            //zip.Save();
         }
     }
 

--- a/Utilizr/Info/AppInfo.cs
+++ b/Utilizr/Info/AppInfo.cs
@@ -216,8 +216,7 @@ namespace Utilizr.Info
 
                 void addFolderToZip(ZipLogsAdditionalItem folder)
                 {
-                    //var filesToAdd = Directory.EnumerateFiles(folder.Path, "*", enumOptions);
-                    var filesToAdd = Directory.GetFiles(folder.Path, "*", SearchOption.AllDirectories);
+                    var filesToAdd = Directory.EnumerateFiles(folder.Path, "*", enumOptions);
                     foreach (var file in filesToAdd)
                     {
                         try

--- a/Utilizr/Info/AppInfo.cs
+++ b/Utilizr/Info/AppInfo.cs
@@ -229,12 +229,12 @@ namespace Utilizr.Info
 
                             var archiveEntry = zip.CreateEntry(nameInZip);
                             using var archiveStream = archiveEntry.Open();
-                            using var fs = new FileStream(file, FileMode.Open, FileAccess.Read);
+                            using var fs = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                             fs.CopyTo(archiveStream);
                         }
                         catch (Exception ex)
                         {
-                            
+                            System.Diagnostics.Debug.WriteLine($"Failed to add {file} to archive {destinationFile}. Error = {ex.Message}");
                         }
                     }
                 }

--- a/Utilizr/Utilizr.csproj
+++ b/Utilizr/Utilizr.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetZip" Version="1.16.0" />
+    <!--<PackageReference Include="DotNetZip" Version="1.16.0" />-->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/Utilizr/Utilizr.csproj
+++ b/Utilizr/Utilizr.csproj
@@ -18,7 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--<PackageReference Include="DotNetZip" Version="1.16.0" />-->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
- DotNetZip has a known vulnerability, [CVE-2024-48510](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2024-48510).
    - This NuGet package hasn't been updated in sometime, all versions are exploitable. 
- These changes break this NuGet package dependency using `System.IO.Compression` by updating:
    -  `AppInfo.ZipLogs()`
    - `RotatingFileHandler.ArchiveFile()`