### PR TITLE
Added WpfSpec.IsUsingHardwareRendering()

### DIFF
--- a/Utilizr.WPF/Util/WpfSpec.cs
+++ b/Utilizr.WPF/Util/WpfSpec.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using Microsoft.Win32;
+using System;
 using System.Windows;
+using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using Utilizr.Logging;
@@ -29,6 +31,57 @@ namespace Utilizr.WPF.Util
             {
                 Log.Exception("wpf_spec", ex);
             }
+        }
+
+        /// <summary>
+        /// <see cref="IsHardwareRendering"/> and <see cref="IsFullHardwareRendering"/> uses <see cref="RenderCapability.Tier"/> which
+        /// is purely hardware based - does this machine have the hardware capable of hardware acceleration. However, WPF may still be
+        /// using software only rendering even when the machine is capable. The precedence order for software rendering is:
+        /// - DisableHWAcceleration registry key
+        /// - ProcessRenderMode (whole WPF process)
+        /// - RenderMode per-target (window)
+        /// This function checks all of the above in an attempt to detect software only rendering.
+        /// </summary>
+        /// <param name="window">Optional window to use when checking per target. Defaults to MainWindow.</param>
+        /// <returns>False if software rendering detected, null on error, otherwise true.</returns>
+        public static bool? IsUsingHardwareRendering(Window? window = null)
+        {
+            if (!IsHardwareRendering)
+                return false; // no DirectX 9 support
+
+            // window level
+            var win = window ?? Application.Current.MainWindow;
+            if (win == null)
+            {
+                Log.Warning(nameof(WpfSpec), "Unable to check per-target for software rendering due to null window.");
+            }
+            else
+            {
+                var hwndSource = PresentationSource.FromVisual(window) as HwndSource;
+                var hwndTarget = hwndSource?.CompositionTarget;
+                if (hwndTarget?.RenderMode == RenderMode.SoftwareOnly)
+                    return false;
+            }
+
+            // wpf process level
+            if (RenderOptions.ProcessRenderMode == RenderMode.SoftwareOnly)
+                return false;
+
+            // machine wide level
+            try
+            {
+                var regKey = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Avalon.Graphics");
+                var disabled = regKey?.GetValue("DisableHWAcceleration") as int?;
+                if (disabled == 1)
+                    return false; // WPF disabled system wide
+            }
+            catch (Exception ex)
+            {
+                Log.Exception(nameof(WpfSpec), ex, "Unable to check registry for WPF hardware rendering");
+                return null;
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
Checks various options in an attempt to detect whether hardware acceleration is disabled.

The current [RenderCapability.Tier](https://learn.microsoft.com/en-us/dotnet/api/system.windows.media.rendercapability.tier?view=windowsdesktop-9.0#system-windows-media-rendercapability-tier) only checks if the hardware exists, not whether WPF is rendering with it. This new function now also checks:

- If the [DisableHSAccerlation](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/graphics-multimedia/graphics-rendering-registry-settings?view=netframeworkdesktop-4.8#disable-hardware-acceleration-option) registry key exists to disable machine wide for WPF applications.
- If the [RenderMode](https://learn.microsoft.com/en-us/dotnet/api/system.windows.interop.hwndtarget.rendermode?view=windowsdesktop-9.0) property has been set to `SoftwareOnly` for a specific `Window`.
- The [ProcessRenderMode](https://learn.microsoft.com/en-us/dotnet/api/system.windows.media.renderoptions.processrendermode?view=windowsdesktop-9.0) for a preference for the whole WPF application.