### PR TITLE
VPN changes

### DIFF
--- a/Utilizr.Vpn.Ras/RasNativeProvidor.cs
+++ b/Utilizr.Vpn.Ras/RasNativeProvidor.cs
@@ -196,7 +196,7 @@ namespace Utilizr.Vpn.Ras
             Disconnect();
         }
 
-        public Task Connect(IConnectionStartParams startParams)
+        public Task<string> Connect(IConnectionStartParams startParams)
         {
             return Task.Run(() =>
             {
@@ -239,6 +239,8 @@ namespace Utilizr.Vpn.Ras
                     OnDisconnected(_currentServer, _context);
                     _rasDialerDone.Set();
                 }
+
+                return _currentServer;
             });
         }
 

--- a/Utilizr.Vpn/IVPNController.cs
+++ b/Utilizr.Vpn/IVPNController.cs
@@ -24,7 +24,7 @@ namespace Utilizr.Vpn
 
         event EventHandler TapDriverInstallationRequired;
 
-        Task ConnectAsync(IConnectionStartParams startParams);
+        Task<string> ConnectAsync(IConnectionStartParams startParams);
 
         Task DisconnectAsync();
 

--- a/Utilizr.Vpn/IVPNController.cs
+++ b/Utilizr.Vpn/IVPNController.cs
@@ -3,8 +3,8 @@
 namespace Utilizr.Vpn
 {
 
-    public delegate void ConnectionStateHandler(object sender, string host, Exception? error, object? userContext=null);
-    public delegate void UsageHandler(object sender, string host, BandwidthUsage usage, object? userContext = null);
+    public delegate void ConnectionStateHandler(object? sender, string host, Exception? error, object? userContext=null);
+    public delegate void UsageHandler(object? sender, string host, BandwidthUsage usage, object? userContext = null);
 
     public interface IVpnController: IDisposable
     {
@@ -107,6 +107,8 @@ namespace Utilizr.Vpn
         CISCO_IPSEC = 4,
         SSTP = 5,
         OPEN_VPN = 6,
+        WIREGUARD = 7,
+        HYDRA = 8,
     }
 
     public enum ConnectionState

--- a/Utilizr.Vpn/IVPNProvider.cs
+++ b/Utilizr.Vpn/IVPNProvider.cs
@@ -16,7 +16,7 @@ namespace Utilizr.Vpn
         TimeSpan ConnectedDuration { get; }
         bool IsConnected { get; }
 
-        string CurrentServer { get; }
+        string? CurrentServer { get; }
 
         event ConnectionStateHandler Connecting;
         event ConnectionStateHandler Connected;

--- a/Utilizr.Vpn/IVPNProvider.cs
+++ b/Utilizr.Vpn/IVPNProvider.cs
@@ -11,7 +11,7 @@ namespace Utilizr.Vpn
         /// Same as <see cref="Disconnect"/> but will always fire disconnecting / disconnected events.
         /// </summary>
         void Abort();
-        Task Connect(IConnectionStartParams startParams);
+        Task<string> Connect(IConnectionStartParams startParams);
         BandwidthUsage Usage { get; }
         TimeSpan ConnectedDuration { get; }
         bool IsConnected { get; }

--- a/Utilizr.Vpn/OpenVpn/OpenVPNProvider.cs
+++ b/Utilizr.Vpn/OpenVpn/OpenVPNProvider.cs
@@ -39,12 +39,13 @@ namespace Utilizr.Vpn.OpenVpn
         public string CurrentServer => _currentServer;
         public object CurrentUserContext => _currentContext;
 
-        public async Task Connect(IConnectionStartParams startParams)
+        public async Task<string> Connect(IConnectionStartParams startParams)
         {
             _currentServer = startParams.Hostname;
             _currentContext = startParams.Context;
 
             await ConnectOpenVPNAsync(startParams);
+            return _currentServer;
         }
 
         public void Disconnect()

--- a/Utilizr.Vpn/VPNController.cs
+++ b/Utilizr.Vpn/VPNController.cs
@@ -26,7 +26,7 @@ namespace Utilizr.Vpn
 
         public Exception? LastError { get; private set; }
 
-        public ConnectionType CurrentConnectionType { get; private set; } = ConnectionType.PPTP;
+        public ConnectionType CurrentConnectionType { get; private set; }
 
         public bool SupressErrors { get; set; }
 
@@ -130,6 +130,7 @@ namespace Utilizr.Vpn
                 CurrentProvider = provider;
 
                 await provider.Connect(startParams);
+                CurrentConnectionType = startParams.ConnectionType;
             }
             catch (Exception ex)
             {

--- a/Utilizr.Vpn/VPNController.cs
+++ b/Utilizr.Vpn/VPNController.cs
@@ -30,7 +30,7 @@ namespace Utilizr.Vpn
 
         public bool SupressErrors { get; set; }
 
-        public VpnController(UserPassHandler? authenticationHandler, bool initializeNow = true, params IVpnProvider[] providers)
+        public VpnController(UserPassHandler authenticationHandler, bool initializeNow = true, params IVpnProvider[] providers)
         {
             _userPassHandler = authenticationHandler;
             Providers = providers;

--- a/Utilizr.Vpn/VPNController.cs
+++ b/Utilizr.Vpn/VPNController.cs
@@ -84,13 +84,14 @@ namespace Utilizr.Vpn
         public event ConnectionStateHandler ConnectError;
         public event EventHandler DurationUpdate;
 
-        public Task ConnectAsync(IConnectionStartParams startParams)
+        public Task<string> ConnectAsync(IConnectionStartParams startParams)
         {
             return Task.Run(() => Connect(startParams));
         }
 
-        async Task Connect(IConnectionStartParams startParams)
+        async Task<string> Connect(IConnectionStartParams startParams)
         {
+            var connectedCountry = string.Empty;
             try
             {
                 LastError = null;
@@ -129,7 +130,7 @@ namespace Utilizr.Vpn
 
                 CurrentProvider = provider;
 
-                await provider.Connect(startParams);
+                connectedCountry = await provider.Connect(startParams);
                 CurrentConnectionType = startParams.ConnectionType;
             }
             catch (Exception ex)
@@ -141,6 +142,8 @@ namespace Utilizr.Vpn
             {
                 throw LastError;
             }
+
+            return connectedCountry;
         }
 
 

--- a/Utilizr.WPF/Utilizr.WPF.csproj
+++ b/Utilizr.WPF/Utilizr.WPF.csproj
@@ -7,6 +7,7 @@
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>disable</ImplicitUsings>
         <EnableWindowsTargeting>True</EnableWindowsTargeting>
+        <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Utilizr.Win.Tests/Utilizr.Win.Tests.csproj
+++ b/Utilizr.Win.Tests/Utilizr.Win.Tests.csproj
@@ -8,6 +8,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Utilizr.Win.TrayIcon/Interop/WinApi.cs
+++ b/Utilizr.Win.TrayIcon/Interop/WinApi.cs
@@ -20,25 +20,25 @@ namespace Utilizr.Win.TrayIcon.Interop
         /// </summary>
         [DllImport("USER32.DLL", EntryPoint = "CreateWindowExW", SetLastError = true)]
         public static extern IntPtr CreateWindowEx(
-            int dwExStyle, 
+            IntPtr dwExStyle, 
             [MarshalAs(UnmanagedType.LPWStr)] string lpClassName,
             [MarshalAs(UnmanagedType.LPWStr)] string lpWindowName,
-            int dwStyle,
+            IntPtr dwStyle,
             int x,
             int y,
             int nWidth,
             int nHeight,
-            uint hWndParent,
-            int hMenu,
-            int hInstance,
-            int lpParam);
+            IntPtr hWndParent,
+            IntPtr hMenu,
+            IntPtr hInstance,
+            IntPtr lpParam);
 
 
         /// <summary>
         /// Processes a default windows procedure.
         /// </summary>
         [DllImport("USER32.DLL")]
-        public static extern long DefWindowProc(IntPtr hWnd, uint msg, uint wparam, uint lparam);
+        public static extern long DefWindowProc(IntPtr hWnd, uint msg, IntPtr wparam, IntPtr lparam);
 
         /// <summary>
         /// Registers the helper window class.

--- a/Utilizr.Win.TrayIcon/Interop/WindowClass.cs
+++ b/Utilizr.Win.TrayIcon/Interop/WindowClass.cs
@@ -7,14 +7,14 @@ namespace Utilizr.Win.TrayIcon.Interop
     /// Callback delegate which is used by the Windows API to
     /// submit window messages.
     /// </summary>
-    public delegate long WindowProcedureHandler(IntPtr hwnd, uint uMsg, uint wparam, uint lparam);
+    public delegate long WindowProcedureHandler(IntPtr hwnd, uint uMsg, IntPtr wparam, IntPtr lparam);
 
 
     /// <summary>
     /// Win API WNDCLASS struct - represents a single window.
     /// Used to receive window messages.
     /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
     public struct WindowClass
     {
         public uint style;

--- a/Utilizr.Win.TrayIcon/Interop/WindowMessageSink.cs
+++ b/Utilizr.Win.TrayIcon/Interop/WindowMessageSink.cs
@@ -180,14 +180,16 @@ namespace Utilizr.Win.TrayIcon.Interop
             wc.lpszClassName = WindowId;
 
             // Register the window class
-            WinApi.RegisterClass(ref wc);
+            var result = WinApi.RegisterClass(ref wc);
+            if (result == 0)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
 
             // Get the message used to indicate the taskbar has been restarted
             // This is used to re-add icons when the taskbar restarts
             taskbarRestartMessageId = WinApi.RegisterWindowMessage("TaskbarCreated");
 
             // Create the message window
-            MessageWindowHandle = WinApi.CreateWindowEx(0, WindowId, "", 0, 0, 0, 1, 1, 0, 0, 0, 0);
+            MessageWindowHandle = WinApi.CreateWindowEx(IntPtr.Zero, WindowId, "", IntPtr.Zero, 0, 0, 1, 1, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
 
             if (MessageWindowHandle == IntPtr.Zero)
             {
@@ -203,7 +205,7 @@ namespace Utilizr.Win.TrayIcon.Interop
         /// <summary>
         /// Callback method that receives messages from the taskbar area.
         /// </summary>
-        private long OnWindowMessageReceived(IntPtr hwnd, uint messageId, uint wparam, uint lparam)
+        private long OnWindowMessageReceived(IntPtr hwnd, uint messageId, IntPtr wparam, IntPtr lparam)
         {
             if (messageId == taskbarRestartMessageId)
             {
@@ -227,7 +229,7 @@ namespace Utilizr.Win.TrayIcon.Interop
         /// or higher, this parameter can be used to resolve mouse coordinates.
         /// Currently not in use.</param>
         /// <param name="lParam">Provides information about the event.</param>
-        private void ProcessWindowMessage(uint msg, uint wParam, uint lParam)
+        private void ProcessWindowMessage(uint msg, IntPtr wParam, IntPtr lParam)
         {
             if (msg != CallbackMessageId) return;
 

--- a/Utilizr.Win.TrayIcon/Utilizr.Win.TrayIcon.csproj
+++ b/Utilizr.Win.TrayIcon/Utilizr.Win.TrayIcon.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Utilizr.Win/FileSystem/ZipFileEx.cs
+++ b/Utilizr.Win/FileSystem/ZipFileEx.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace Utilizr.Win.FileSystem
+{
+    public static class ZipFileEx
+    {
+        public delegate void ExtractProgressFileCountUpdate(long filesExtracted, long filesInArchive, double percentageExtractedCount);
+        public delegate void ExtractProgressFileSizeUpdate(long sizeExtracted, long uncompressedTotalSize, double percentageExtractedSize);
+
+        /// <summary>
+        /// Extract a zip to a given location, preserving any relative folders within the archive to the destination directory.
+        /// Creates any necessary folders to ensure extraction does not fail.
+        /// </summary>
+        /// <param name="zipArchive">An opened ZipArchive with read permissions.</param>
+        /// <param name="extractDestination">The destination folder where to place the extracted archive.</param>
+        /// <param name="countProgressCallback">Optional progress callback with file counts, percentage based on these values.</param>
+        /// <param name="sizeProgressCallback">Optional progress callback with file sizes, percentage based on these values.</param>
+        public static void ExtractToDirectory(
+            this ZipArchive zipArchive,
+            string extractDestination,
+            bool overwriteDestinationFiles,
+            ExtractProgressFileCountUpdate? countProgressCallback = null,
+            ExtractProgressFileSizeUpdate? sizeProgressCallback = null)
+        {
+            double safeSizeExtractedPercent = 0;
+            long uncompressedSizeNowExtracted = 0;
+            long uncompressedSize = Math.Max(zipArchive.Entries.Sum(p => p.Length), 1); // avoid divide by 0
+
+            long filesNowExtracted = 0;
+            long filesToExtract = zipArchive.Entries.Count;
+            double extractedCountPercent = 0;
+
+            foreach (var zipEntry in zipArchive.Entries)
+            {
+                // Observed folders within an archive using unix style '/' rather than '\' for Windows directory separator character
+                var entryDestination = Path.Combine(extractDestination, zipEntry.FullName).Replace('/', '\\');
+
+                if (!zipEntry.Name.Equals(zipEntry.FullName))
+                {
+                    var folder = PathHelper.GetDirectoryName(entryDestination);
+                    if (!Directory.Exists(folder))
+                        Directory.CreateDirectory(folder);
+                }
+
+                zipEntry.ExtractToFile(entryDestination, overwriteDestinationFiles);
+
+                filesNowExtracted++;
+                extractedCountPercent = filesNowExtracted / (double)filesToExtract;
+                countProgressCallback?.Invoke(filesNowExtracted, filesToExtract, extractedCountPercent);
+
+                uncompressedSizeNowExtracted += zipEntry.Length;
+                var sizePercentage = uncompressedSizeNowExtracted / (double)uncompressedSize;
+                safeSizeExtractedPercent = Math.Max(sizePercentage, safeSizeExtractedPercent); // ensure we're returning something sensible
+                sizeProgressCallback?.Invoke(uncompressedSizeNowExtracted, uncompressedSize, safeSizeExtractedPercent);
+            }
+        }
+    }
+}

--- a/Utilizr.Win/Utilizr.Win.csproj
+++ b/Utilizr.Win/Utilizr.Win.csproj
@@ -7,6 +7,7 @@
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>Utilizr.Win</RootNamespace>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Utilizr.Win32/Utilizr.Win32.csproj
+++ b/Utilizr.Win32/Utilizr.Win32.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Added `ConnectionType.WIREGUARD` and `ConnectionType.HYDRA` protocol enums.
- `IVpnProvider` `Connect()` interface method now returns `Task<string>` with host information, rather than `Task`.
- Fixed `Utilizr.Win.TrayIcon` to work on platforms other than `x86`.
- Added `ZipFileEx` for an `ExtractToDirectory()` `ZipArchive` extension method.