### PR TITLE
Secure RestClient logging

### DIFF
--- a/Utilizr.RestClient.Tests/ApiRequestTests.cs
+++ b/Utilizr.RestClient.Tests/ApiRequestTests.cs
@@ -1,0 +1,98 @@
+﻿using NUnit.Framework;
+using Utilizr.Rest.Client;
+
+namespace Utilizr.RestClient.Tests
+{
+    [TestFixture(Category = "RestClient")]
+    public class ApiRequestTests
+    {
+        [TestCase("https://token.com?token=abc123", "https://token.com?token=***")]
+        [TestCase("https://token.com?foo=1&token=abc123", "https://token.com?foo=1&token=***")]
+        [TestCase("https://token.com?token=abc123&foo=1", "https://token.com?token=***&foo=1")]
+        [TestCase("https://token.com?foo=1&token=abc123&bar=2", "https://token.com?foo=1&token=***&bar=2")]
+        [TestCase("https://token.com?foo=1&bar=2", "https://token.com?foo=1&bar=2")]
+        [TestCase("https://token.com", "https://token.com")]
+        [TestCase("https://token.com?TOKEN=abc123", "https://token.com?TOKEN=***")]
+        public void MaskQueryParameter_ShouldMaskExpectedValue(string input, string expected)
+        {
+            var result = ApiRequest<object>.MaskUrlQueryParameter(input, "token");
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void MaskQueryParameter_ShouldUseCustomMask()
+        {
+            var input = "https://example.com?foo=1&token=abc123";
+            var result = ApiRequest<object>.MaskUrlQueryParameter(input, "token", "[REDACTED]");
+
+            Assert.That(
+                result,
+                Is.EqualTo("https://example.com?foo=1&token=[REDACTED]"));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        public void MaskQueryParameter_ShouldReturnOriginal_WhenUrlIsNullOrEmpty(string input)
+        {
+            var result = ApiRequest<object>.MaskUrlQueryParameter(input, "token");
+            Assert.That(result, Is.EqualTo(input));
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        public void MaskQueryParameter_ShouldReturnOriginal_WhenParameterNameIsNullOrEmpty(string parameterName)
+        {
+            var input = "https://example.com?token=abc123";
+            var result = ApiRequest<object>.MaskUrlQueryParameter(input, parameterName);
+            Assert.That(result, Is.EqualTo(input));
+        }
+
+
+        [TestCase(@"{""Password"":""secret""}", @"{""Password"":""***""}")]
+        [TestCase(@"{""Password"": ""secret""}", @"{""Password"": ""***""}")]
+        [TestCase(@"{""Password"" : ""secret""}", @"{""Password"" : ""***""}")]
+        [TestCase("{\r\n\"Password\"\r\n:\r\n\"secret\"\r\n}", "{\r\n\"Password\"\r\n:\r\n\"***\"\r\n}")]
+        [TestCase(@"{""Username"":""bob"",""Password"":""secret""}", @"{""Username"":""bob"",""Password"":""***""}")]
+        [TestCase(@"{""Password"":""secret"",""Username"":""bob""}", @"{""Password"":""***"",""Username"":""bob""}")]
+        [TestCase(@"{""PASSWORD"":""secret""}", @"{""PASSWORD"":""***""}")]
+        [TestCase(@"{""Username"":""bob""}", @"{""Username"":""bob""}")]
+        [TestCase(@"{}", @"{}")]
+        public void MaskRawJsonProperty_ShouldMaskExpectedProperty(string input, string expected)
+        {
+            var result = ApiRequest<object>.MaskRawJsonProperty(input, "Password");
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void MaskRawJsonProperty_ShouldUseCustomMask()
+        {
+            var input = @"{""Password"":""secret""}";
+            var result = ApiRequest<object>.MaskRawJsonProperty(input, "Password", "[REDACTED]");
+            Assert.That(
+                result,
+                Is.EqualTo(@"{""Password"":""[REDACTED]""}"));
+        }
+
+        [Test]
+        public void MaskRawJsonProperty_ShouldMaskAllMatchingProperties()
+        {
+            var input = @"{""Password"":""first"", ""Nested"":{""Password"":""second""}}";
+
+            var result = ApiRequest<object>.MaskRawJsonProperty(input, "Password");
+
+            Assert.That(result, Does.Not.Contain("first"));
+            Assert.That(result, Does.Not.Contain("second"));
+            Assert.That(result, Is.EqualTo(@"{""Password"":""***"", ""Nested"":{""Password"":""***""}}"));
+        }
+
+        [Test]
+        public void MaskRawJsonProperty_ShouldNotMaskPartialPropertyNames()
+        {
+            var input = @"{""Password"":""secret"", ""PasswordHash"":""abc123""}";
+            var result = ApiRequest<object>.MaskRawJsonProperty(input, "Password");
+
+            Assert.That(result, Does.Contain(@"""PasswordHash"":""abc123"""));
+            Assert.That(result, Does.Contain(@"""Password"":""***"""));
+        }
+    }
+}

--- a/Utilizr.RestClient.Tests/ApiRequestTests.cs
+++ b/Utilizr.RestClient.Tests/ApiRequestTests.cs
@@ -32,7 +32,7 @@ namespace Utilizr.RestClient.Tests
 
         [TestCase(null)]
         [TestCase("")]
-        public void MaskQueryParameter_ShouldReturnOriginal_WhenUrlIsNullOrEmpty(string input)
+        public void MaskQueryParameter_ShouldReturnOriginal_WhenUrlIsNullOrEmpty(string? input)
         {
             var result = ApiRequest<object>.MaskUrlQueryParameter(input, "token");
             Assert.That(result, Is.EqualTo(input));
@@ -40,7 +40,7 @@ namespace Utilizr.RestClient.Tests
 
         [TestCase(null)]
         [TestCase("")]
-        public void MaskQueryParameter_ShouldReturnOriginal_WhenParameterNameIsNullOrEmpty(string parameterName)
+        public void MaskQueryParameter_ShouldReturnOriginal_WhenParameterNameIsNullOrEmpty(string? parameterName)
         {
             var input = "https://example.com?token=abc123";
             var result = ApiRequest<object>.MaskUrlQueryParameter(input, parameterName);

--- a/Utilizr.RestClient.Tests/Utilizr.RestClient.Tests.csproj
+++ b/Utilizr.RestClient.Tests/Utilizr.RestClient.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Utilizr.RestClient\Utilizr.RestClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Utilizr.RestClient/AbstractRestClient.cs
+++ b/Utilizr.RestClient/AbstractRestClient.cs
@@ -78,43 +78,43 @@ namespace Utilizr.Rest.Client
             try
             {
                 LogRequest(apiRequest, headers);
-                var response = this.Execute<T>(request);
-                LogResponse(apiRequest, response);
+                apiRequest.Response = this.Execute<T>(request);
+                LogResponse(apiRequest, apiRequest.Response);
 
-                if (string.IsNullOrEmpty(response.Content))
+                if (string.IsNullOrEmpty(apiRequest.Response.Content))
                 {
                     // todo: no internet connection check / custom error thrown so we can show a nicer error message
 
                     // Only throw for no content, otherwise stuff like HTTP 400 will cause it to throw
                     // when in reality we want to show a custom api error message of something like
                     // credentials don't match, or weak password detected on signup, etc
-                    response.ThrowIfError();
+                    apiRequest.Response.ThrowIfError();
                 }
 
-                if (!response.IsSuccessStatusCode)
+                if (!apiRequest.Response.IsSuccessStatusCode)
                 {
-                    var description = response.StatusDescription;
+                    var description = apiRequest.Response.StatusDescription;
 
-                    if (response.StatusCode == HttpStatusCode.Unauthorized)
-                        OnAuthenticationError(response.StatusCode, description);
+                    if (apiRequest.Response.StatusCode == HttpStatusCode.Unauthorized)
+                        OnAuthenticationError(apiRequest.Response.StatusCode, description);
 
-                    var detailedErrorDescription = apiRequest.GetCustomApiExceptionDescriptionOnUnsuccessfulStatusCode(response.StatusCode, response.Data);
+                    var detailedErrorDescription = apiRequest.GetCustomApiExceptionDescriptionOnUnsuccessfulStatusCode(apiRequest.Response.StatusCode, apiRequest.Response.Data);
                     if (!string.IsNullOrEmpty(detailedErrorDescription))
                         description = detailedErrorDescription;
 
-                    OnAnyHttpStatusError(request.Method.ToString().ToUpperInvariant(), _serviceUrl, request.Resource, response.StatusCode, description);
+                    OnAnyHttpStatusError(request.Method.ToString().ToUpperInvariant(), _serviceUrl, request.Resource, apiRequest.Response.StatusCode, description);
 
-                    throw new ApiException((int)response.StatusCode, description, response.Content);
+                    throw new ApiException((int)apiRequest.Response.StatusCode, description, apiRequest.Response.Content);
                 }
 
                 //var responseData = JsonConvert.DeserializeObject<T>(response.Content!);
-                if (response.Data == null)
-                    throw new Exception($"Failed to deserialise response on {apiRequest.Endpoint}", response.ErrorException);
+                if (apiRequest.Response.Data == null)
+                    throw new Exception($"Failed to deserialise response on {apiRequest.Endpoint}", apiRequest.Response.ErrorException);
 
-                apiRequest.PostProcessing(response.Data);
+                apiRequest.PostProcessing(apiRequest.Response.Data);
 
-                NotifyRequestCompleted<T>(apiRequest, response.Data);
-                return response.Data;
+                NotifyRequestCompleted<T>(apiRequest, apiRequest.Response.Data);
+                return apiRequest.Response.Data;
             }
             catch (Exception e)
             {
@@ -152,7 +152,7 @@ namespace Utilizr.Rest.Client
             debugDict["Error"] = response.ErrorMessage ?? response.ErrorException?.Message;
             try
             {
-                debugDict["ResponseData"] = apiRequest.GetObjectForResponseLogging(JsonConvert.DeserializeObject<T>(response.Content!)!)!;
+                debugDict["ResponseData"] = apiRequest.GetObjectForResponseLogging()!;
             }
             catch (Exception)
             {

--- a/Utilizr.RestClient/RequestHelpers.cs
+++ b/Utilizr.RestClient/RequestHelpers.cs
@@ -3,6 +3,7 @@ using RestSharp;
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Text.RegularExpressions;
 
 namespace Utilizr.Rest.Client
 {
@@ -26,10 +27,15 @@ namespace Utilizr.Rest.Client
     public interface IApiRequest<TResponse> : IApiRequest
     {
         /// <summary>
-        /// Gets the object for request logging.
-        /// You should override this method is for example you need to remove any sensitive information from a specific object before logging
+        /// Raw RestSharp response instance.
         /// </summary>
-        /// <returns>The object for request logging.</returns>
+        public RestResponse<TResponse>? Response { get; set; }
+
+        /// <summary>
+        /// Gets the object for request logging.
+        /// Changing this object will have no effect on the data being sent.
+        /// </summary>
+        /// <returns>The new object for request logging.</returns>
         object GetObjectForRequestLogging();
 
         /// <summary>
@@ -48,7 +54,7 @@ namespace Utilizr.Rest.Client
         /// Note, the changes you make on this response object only affect logging.
         /// </summary>
         /// <returns>The object for response logging.</returns>
-        TResponse GetObjectForResponseLogging(TResponse response);
+        TResponse GetObjectForResponseLogging();
 
         /// <summary>
         /// Return an optional more detailed error message instead of the stardand HTTP status.
@@ -61,6 +67,9 @@ namespace Utilizr.Rest.Client
 
     public abstract class ApiRequest<TResponse> : IApiRequest<TResponse>
     {
+        [JsonIgnore]
+        public RestResponse<TResponse>? Response { get; set; }
+
         [JsonIgnore]
         public string EndpointLogStr => $"({MethodLogStr}){Endpoint}";
 
@@ -79,6 +88,11 @@ namespace Utilizr.Rest.Client
 
         public bool LogRequest { get; set; } = true;
 
+        /// <summary>
+        /// Value used to mask sensitive data in requests/responses.
+        /// </summary>
+        public static string Mask { get; set; } = "***";
+
         public ApiRequest(object? body = null)
         {
             Body = body;
@@ -88,6 +102,7 @@ namespace Utilizr.Rest.Client
         /// Optionally add any extra headers.
         /// </summary>
         public virtual Dictionary<string, string>? GetExtraRequestSpecificHeaders() { return null; }
+
 
         /// <summary>
         /// Gets the object for request logging.
@@ -122,13 +137,16 @@ namespace Utilizr.Rest.Client
         /// Note, the changes you make on this response object only affect logging.
         /// </summary>
         /// <returns>The object for response logging.</returns>
-        public virtual TResponse GetObjectForResponseLogging(TResponse response)
+        public virtual TResponse GetObjectForResponseLogging()
         {
-            return response;
+            if (Response == null)
+                throw new InvalidOperationException("Cannot get response object for logging without a response");
+
+            return JsonConvert.DeserializeObject<TResponse>(Response.Content!)!;
         }
 
         /// <summary>
-        /// Return an optional more detailed error message instead of the stardand HTTP status.
+        /// Return an optional more detailed error message instead of the standard HTTP status.
         /// </summary>
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="response">Types response for the attempted request.</param>
@@ -136,6 +154,34 @@ namespace Utilizr.Rest.Client
         public virtual string? GetCustomApiExceptionDescriptionOnUnsuccessfulStatusCode(HttpStatusCode statusCode, TResponse? response)
         {
             return null;
+        }
+
+        /// <summary>
+        /// Some API responses may have a JSON property themselves.
+        /// Helper method to find the given property within the JSON, and change it's value to avoid logging anything sensitive.
+        /// </summary>
+        /// <param name="rawJson">RAW JSOn returned as a property on an API response</param>
+        /// <param name="jsonKey">The matching property name, not case sensitive. E.g. MyProperty</param>
+        /// <param name="maskedValue">Optional mask value, defaulting to the value of <see cref="Mask"/>if null</param>
+        /// <returns></returns>
+        public string MaskRawJsonProperty(string rawJson, string jsonKey, string? maskedValue = null)
+        {
+            maskedValue ??= Mask;
+
+            // If we use regex we can handle scenarios such as this, where IndexOf would fail:
+            // "Key":"value"
+            // "Key": "value"
+            // "Key" : "value"
+            // "Key"
+            // :
+            // "value"
+
+            var pattern = $"(\"{Regex.Escape(jsonKey)}\"\\s*:\\s*\")([^\"]*)(\")";
+
+            return Regex.Replace(
+                rawJson,
+                pattern,
+                $"$1{maskedValue}$3");
         }
     }
 

--- a/Utilizr.RestClient/RequestHelpers.cs
+++ b/Utilizr.RestClient/RequestHelpers.cs
@@ -30,10 +30,10 @@ namespace Utilizr.Rest.Client
         public RestResponse<TResponse>? Response { get; set; }
 
         /// <summary>
-        /// Gets the object for request logging.
+        /// You should override this method if for example you need to remove any sensitive information from a specific object before logging.
         /// Changing this object will have no effect on the data being sent.
         /// </summary>
-        /// <returns>The new object for request logging.</returns>
+        /// <returns>A new object for request logging.</returns>
         object GetObjectForRequestLogging();
 
         /// <summary>
@@ -42,16 +42,16 @@ namespace Utilizr.Rest.Client
         Dictionary<string, string>? GetExtraRequestSpecificHeaders();
 
         /// <summary>
-        /// Override post processing to perform internal tasks upon a successful response
+        /// Override post processing to perform internal tasks upon a successful response.
         /// NOTE: this method is NOT async, do not write blocking code in this method
         /// </summary>
         void PostProcessing(TResponse response);
 
         /// <summary>
-        /// Gets the object for response logging. Override this method if you need to remove sensitive data before logging
+        /// Gets the object for response logging. Override this method if you need to remove sensitive data before logging.
         /// Note, the changes you make on this response object only affect logging.
         /// </summary>
-        /// <returns>The object for response logging.</returns>
+        /// <returns>A new object for response logging.</returns>
         TResponse GetObjectForResponseLogging();
 
         /// <summary>
@@ -100,7 +100,6 @@ namespace Utilizr.Rest.Client
         /// Optionally add any extra headers.
         /// </summary>
         public virtual Dictionary<string, string>? GetExtraRequestSpecificHeaders() { return null; }
-
 
         /// <summary>
         /// Gets the object for request logging.
@@ -165,14 +164,6 @@ namespace Utilizr.Rest.Client
         public static string MaskRawJsonProperty(string rawJson, string jsonKey, string? maskedValue = null)
         {
             maskedValue ??= Mask;
-
-            // If we use regex we can handle scenarios such as this, where IndexOf would fail:
-            // "Key":"value"
-            // "Key": "value"
-            // "Key" : "value"
-            // "Key"
-            // :
-            // "value"
 
             var pattern = $"(\"{Regex.Escape(jsonKey)}\"\\s*:\\s*\")([^\"]*)(\")";
 

--- a/Utilizr.RestClient/RequestHelpers.cs
+++ b/Utilizr.RestClient/RequestHelpers.cs
@@ -91,7 +91,7 @@ namespace Utilizr.Rest.Client
         /// <summary>
         /// Value used to mask sensitive data in requests/responses.
         /// </summary>
-        public static string Mask { get; set; } = "***";
+        public static string Mask { get; set; } = "***"; // Update unit test if changing default value
 
         public ApiRequest(object? body = null)
         {
@@ -160,11 +160,11 @@ namespace Utilizr.Rest.Client
         /// Some API responses may have a JSON property themselves.
         /// Helper method to find the given property within the JSON, and change it's value to avoid logging anything sensitive.
         /// </summary>
-        /// <param name="rawJson">RAW JSOn returned as a property on an API response</param>
+        /// <param name="rawJson">RAW JSON returned as a property on an API response</param>
         /// <param name="jsonKey">The matching property name, not case sensitive. E.g. MyProperty</param>
         /// <param name="maskedValue">Optional mask value, defaulting to the value of <see cref="Mask"/>if null</param>
         /// <returns></returns>
-        public string MaskRawJsonProperty(string rawJson, string jsonKey, string? maskedValue = null)
+        public static string MaskRawJsonProperty(string rawJson, string jsonKey, string? maskedValue = null)
         {
             maskedValue ??= Mask;
 
@@ -181,7 +181,31 @@ namespace Utilizr.Rest.Client
             return Regex.Replace(
                 rawJson,
                 pattern,
-                $"$1{maskedValue}$3");
+                $"$1{maskedValue}$3",
+                RegexOptions.IgnoreCase
+            );
+        }
+
+        /// <summary>
+        /// Mask a specific query parameter's value within a URL.
+        /// </summary>
+        /// <param name="url">URL with the sensitive query parameters</param>
+        /// <param name="parameterName">The matching query parameter name, not case sensitive. E.g. token</param>
+        /// <param name="maskedValue">Optional mask value, defaulting to the value of <see cref="Mask"/>if null</param>
+        /// <returns></returns>
+        public static string MaskUrlQueryParameter(string url, string parameterName, string? maskedValue = null)
+        {
+            maskedValue ??= Mask;
+
+            if (string.IsNullOrEmpty(url) || string.IsNullOrEmpty(parameterName))
+                return url;
+
+            return Regex.Replace(
+                url,
+                $@"([?&]{Regex.Escape(parameterName)}=)[^&]*",
+                $"$1{maskedValue}",
+                RegexOptions.IgnoreCase
+            );
         }
     }
 

--- a/Utilizr.RestClient/RequestHelpers.cs
+++ b/Utilizr.RestClient/RequestHelpers.cs
@@ -1,7 +1,5 @@
 using Newtonsoft.Json;
 using RestSharp;
-using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Text.RegularExpressions;
 
@@ -193,7 +191,7 @@ namespace Utilizr.Rest.Client
         /// <param name="parameterName">The matching query parameter name, not case sensitive. E.g. token</param>
         /// <param name="maskedValue">Optional mask value, defaulting to the value of <see cref="Mask"/>if null</param>
         /// <returns></returns>
-        public static string MaskUrlQueryParameter(string url, string parameterName, string? maskedValue = null)
+        public static string MaskUrlQueryParameter(string url, string? parameterName, string? maskedValue = null)
         {
             maskedValue ??= Mask;
 

--- a/Utilizr.sln
+++ b/Utilizr.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.5.33414.496
+# Visual Studio Version 18
+VisualStudioVersion = 18.6.11828.311 oobstable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Utilizr.Logging", "Utilizr.Logging\Utilizr.Logging.csproj", "{548FA421-6F71-4DFF-96C5-76AA39C788A8}"
 EndProject
@@ -38,6 +38,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Utilizr.Win.TrayIcon", "Utilizr.Win.TrayIcon\Utilizr.Win.TrayIcon.csproj", "{F09575E7-7DBD-4AE5-B66C-D1604D7C8E28}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "get_parent_process_id", "Utilizr.Win.Tests.get_parent_process_id\get_parent_process_id.csproj", "{1C62584A-FC94-4BFA-9E72-C6ABE3DE0363}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Utilizr.RestClient", "Utilizr.RestClient\Utilizr.RestClient.csproj", "{0B4514EC-7B90-34F4-42DE-D140C3A07311}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Utilizr.RestClient.Tests", "Utilizr.RestClient.Tests\Utilizr.RestClient.Tests.csproj", "{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -339,6 +343,38 @@ Global
 		{1C62584A-FC94-4BFA-9E72-C6ABE3DE0363}.Release|x64.Build.0 = Release|Any CPU
 		{1C62584A-FC94-4BFA-9E72-C6ABE3DE0363}.Release|x86.ActiveCfg = Release|Any CPU
 		{1C62584A-FC94-4BFA-9E72-C6ABE3DE0363}.Release|x86.Build.0 = Release|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Debug|x64.Build.0 = Debug|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Debug|x86.Build.0 = Debug|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Release|ARM64.Build.0 = Release|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Release|x64.ActiveCfg = Release|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Release|x64.Build.0 = Release|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Release|x86.ActiveCfg = Release|Any CPU
+		{0B4514EC-7B90-34F4-42DE-D140C3A07311}.Release|x86.Build.0 = Release|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Debug|x64.Build.0 = Debug|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Debug|x86.Build.0 = Debug|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Release|ARM64.Build.0 = Release|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Release|x64.ActiveCfg = Release|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Release|x64.Build.0 = Release|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Release|x86.ActiveCfg = Release|Any CPU
+		{3D8A966C-6CC3-4F4D-A85D-88B4D39520F3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Utilizr/Crypto/AES.cs
+++ b/Utilizr/Crypto/AES.cs
@@ -91,32 +91,33 @@ namespace Utilizr.Crypto
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentException($"{nameof(key)} cannot be null or empty.");
 
-            using (var aes = Aes.Create())
-            {
-                aes.Mode = cipherMode;
-                aes.BlockSize = blockSize;
-                aes.Key = Encoding.UTF8.GetBytes(key);
+            using var aes = Aes.Create();
+            aes.Mode = cipherMode;
+            aes.BlockSize = blockSize;
+            aes.Key = Encoding.UTF8.GetBytes(key);
 
-                var initVectorBytes = new Span<byte>(new byte[initVectorLength]);
-                RandomNumberGenerator.Fill(initVectorBytes);
-                initVector = initVectorBytes.ToArray();
-                aes.IV = initVector;
-                aes.Padding = PaddingMode.PKCS7;
+            var initVectorBytes = new Span<byte>(new byte[initVectorLength]);
+            RandomNumberGenerator.Fill(initVectorBytes);
+            initVector = initVectorBytes.ToArray();
+            aes.IV = initVector;
 
-                var encryptor = aes.CreateEncryptor(aes.Key, aes.IV);
+            // todo: should be using GenerateIV(), but needs more testing.
+            //aes.GenerateIV();
+            //initVector = aes.IV;
 
-                using (MemoryStream memStream = new MemoryStream())
-                using (CryptoStream cryptoStream = new CryptoStream(memStream, encryptor, CryptoStreamMode.Write))
-                {
-                    var bytes = Encoding.UTF8.GetBytes(plainText);
+            aes.Padding = PaddingMode.PKCS7;
 
-                    cryptoStream.Write(bytes, 0, bytes.Length);
-                    cryptoStream.FlushFinalBlock();
+            var encryptor = aes.CreateEncryptor(aes.Key, aes.IV);
 
-                    var cipherTextBytes = memStream.ToArray();
-                    return cipherTextBytes;
-                }
-            }
+            using MemoryStream memStream = new MemoryStream();
+            using CryptoStream cryptoStream = new CryptoStream(memStream, encryptor, CryptoStreamMode.Write);
+            var bytes = Encoding.UTF8.GetBytes(plainText);
+
+            cryptoStream.Write(bytes, 0, bytes.Length);
+            cryptoStream.FlushFinalBlock();
+
+            var cipherTextBytes = memStream.ToArray();
+            return cipherTextBytes;
         }
     }
 }


### PR DESCRIPTION
- Changes to help mask any sensitive data within `IApiRequest`. 
- Breaking change to remove the `TResponse` parameter within `GetObjectForResponseLogging()`.
- Adds helper methods `MaskRawJsonProperty()` and `MaskUrlQueryParameter()`.
- Adds `Utilizr.RestClient.Tests` project for code coverage of the new two helper methods.