### PR TITLE
SHGetKnownFolderPath() | ZipLogsSelective() | GetHeadersForRequestLogging()

### DIFF
--- a/Utilizr.RestClient/AbstractRestClient.cs
+++ b/Utilizr.RestClient/AbstractRestClient.cs
@@ -77,7 +77,7 @@ namespace Utilizr.Rest.Client
 
             try
             {
-                LogRequest(apiRequest, headers);
+                LogRequest(apiRequest, headers); // Can overwrite current headers, important they remained added above first!
                 apiRequest.Response = this.Execute<T>(request);
                 LogResponse(apiRequest, apiRequest.Response);
 
@@ -130,7 +130,7 @@ namespace Utilizr.Rest.Client
 
             var debugDict = new Dictionary<string, object>();
             debugDict["Endpoint"] = apiRequest.Endpoint;
-            debugDict["Headers"] = headers;
+            debugDict["Headers"] = MaskClientRequestHeaders(headers);
             debugDict["RequestParams"] = apiRequest.GetObjectForRequestLogging();
             debugDict["FullUrl"] = $"({apiRequest.MethodLogStr}){_serviceUrl}/{apiRequest.Endpoint}";
 
@@ -208,6 +208,14 @@ namespace Utilizr.Rest.Client
             ApplyClientSpecificHeaders(headers, requestObj, postData);
             return headers;
         }
+
+        /// <summary>
+        /// Optional override to modify headers to avoid sensitive data in logs.
+        /// It's assumed headers have already been added to the request at this point to allow modifying the current instance.
+        /// </summary>
+        /// <param name="headers">Current headers for the request</param>
+        /// <returns>The same dictionary instance, which may contain changes if headers have been masked.</returns>
+        protected virtual Dictionary<string, string> MaskClientRequestHeaders(Dictionary<string, string> headers) { return headers; }
 
         /// <summary>
         /// Optional override to add headers for a specific rest client. 

--- a/Utilizr.RestClient/AbstractRestClient.cs
+++ b/Utilizr.RestClient/AbstractRestClient.cs
@@ -130,7 +130,7 @@ namespace Utilizr.Rest.Client
 
             var debugDict = new Dictionary<string, object>();
             debugDict["Endpoint"] = apiRequest.Endpoint;
-            debugDict["Headers"] = MaskClientRequestHeaders(headers);
+            debugDict["Headers"] = GetHeadersForRequestLogging(headers);
             debugDict["RequestParams"] = apiRequest.GetObjectForRequestLogging();
             debugDict["FullUrl"] = $"({apiRequest.MethodLogStr}){_serviceUrl}/{apiRequest.Endpoint}";
 
@@ -215,7 +215,7 @@ namespace Utilizr.Rest.Client
         /// </summary>
         /// <param name="headers">Current headers for the request</param>
         /// <returns>The same dictionary instance, which may contain changes if headers have been masked.</returns>
-        protected virtual Dictionary<string, string> MaskClientRequestHeaders(Dictionary<string, string> headers) { return headers; }
+        protected virtual Dictionary<string, string> GetHeadersForRequestLogging(Dictionary<string, string> headers) { return headers; }
 
         /// <summary>
         /// Optional override to add headers for a specific rest client. 

--- a/Utilizr.Win/FileSystem/PathHelper.cs
+++ b/Utilizr.Win/FileSystem/PathHelper.cs
@@ -149,7 +149,7 @@ namespace Utilizr.Win.FileSystem
         /// <returns></returns>
         public static string AbsolutePathToSubdirectory(string subPathRoot, string absolutePath)
         {
-            var root = GetPathRoot(absolutePath);
+            var root = GetPathRoot(absolutePath) ?? throw new ArgumentException($"Unable to get root volume from {nameof(absolutePath)}: {absolutePath}");
             var rootAsFolder = root.TrimEnd(new char[] { Path.VolumeSeparatorChar, Path.DirectorySeparatorChar });
 
             var combined = Path.Combine(subPathRoot, rootAsFolder);

--- a/Utilizr.Win/Info/KnownFolders.cs
+++ b/Utilizr.Win/Info/KnownFolders.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using Utilizr.Info;
 using Utilizr.Win.Util;
+using Utilizr.Win32.Kernel32;
 using Utilizr.Win32.Shell32;
 using Utilizr.Win32.Shell32.Flags;
 
@@ -28,6 +29,7 @@ namespace Utilizr.Win.Info
             "{7D1D3A04-DEBB-4115-95CF-2F29DA2920DA}", // SavedSearches
             "{18989B1D-99B5-455B-841C-AB7C74E4DDFC}", // Videos
             "{82A5EA35-D9CD-47C5-9629-E15D2F714E6E}", // Common startup
+            "{F1B32785-6FBA-4FCF-9D55-7B8E7F157091}", // %LOCALAPPDATA% (%USERPROFILE%\AppData\Local)
         };
 
         /// <summary>
@@ -53,26 +55,48 @@ namespace Utilizr.Win.Info
         /// <exception cref="ExternalException">Thrown if the path could not be retrieved.</exception>
         public static string GetPath(KnownFolder knownFolder, bool defaultUser)
         {
-            return GetPath(knownFolder, KnownFolderFlags.DontVerify, defaultUser);
+            return GetPath(knownFolder, KnownFolderFlags.DontVerify, new IntPtr(defaultUser ? -1 : 0));
         }
 
-        private static string GetPath(KnownFolder knownFolder, KnownFolderFlags flags, bool defaultUser)
+        /// <summary>
+        /// Gets the current path to the specified known folder as currently configured.
+        /// This does not require the folder to be existent.
+        /// </summary>
+        /// <param name="knownFolder">The known folder which current path will be returned.</param>
+        /// <param name="defaultUser">The access token for the desired user.</param>
+        /// <returns>The default path of the known folder.</returns>
+        /// <exception cref="ExternalException">Thrown if the path could not be retrieved.</exception>
+        public static string GetPath(KnownFolder knownFolder, IntPtr hToken)
         {
-            int result = Shell32.SHGetKnownFolderPath(
-                new Guid(_knownFolderGuids[(int)knownFolder]),
-                (uint)flags,
-                new IntPtr(defaultUser ? -1 : 0),
-                out IntPtr outPath
-            );
+            return GetPath(knownFolder, KnownFolderFlags.DontUnexpand, hToken);
+        }
 
-            if (result >= 0)
+        private static string GetPath(KnownFolder knownFolder, KnownFolderFlags flags, IntPtr hToken)
+        {
+            IntPtr outPath = IntPtr.Zero;
+            try
             {
-                var path = Marshal.PtrToStringUni(outPath);
-                if (!string.IsNullOrEmpty(path))
-                    return path;
-            }
+                int result = Shell32.SHGetKnownFolderPath(
+                    new Guid(_knownFolderGuids[(int)knownFolder]),
+                    (uint)flags,
+                    hToken,
+                    out outPath
+                );
 
-            throw new ExternalException("Unable to retrieve the known folder path. It may not be available on this system.", result);
+                if (result >= 0)
+                {
+                    var path = Marshal.PtrToStringUni(outPath);
+                    if (!string.IsNullOrEmpty(path))
+                        return path;
+                }
+
+                throw new ExternalException("Unable to retrieve the known folder path. It may not be available on this system.", result);
+            }
+            finally
+            {
+                if (outPath != IntPtr.Zero)
+                    Marshal.FreeCoTaskMem(outPath);
+            }
         }
 
         public static string SafeGetDownloadsFolder()
@@ -169,6 +193,7 @@ namespace Utilizr.Win.Info
         SavedGames,
         SavedSearches,
         Videos,
-        CommonStartup
+        CommonStartup,
+        LocalAppData
     }
 }

--- a/Utilizr/Info/AppInfo.cs
+++ b/Utilizr/Info/AppInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Reflection;
@@ -89,12 +90,13 @@ namespace Utilizr.Info
             }
         }
 
+        public static string DataDirectoryName { get; } = "data";
         private static string? _dataDirectory;
         public static string DataDirectory
         {
             get
             {
-                CreateAppDirectory(ref _dataDirectory, "data");
+                CreateAppDirectory(ref _dataDirectory, DataDirectoryName);
                 return _dataDirectory!;
             }
         }
@@ -109,12 +111,13 @@ namespace Utilizr.Info
             }
         }
 
+        public static string LogDirectoryName { get; } = "logs";
         private static string? _logDirectory;
         public static string LogDirectory
         {
             get
             {
-                CreateAppDirectory(ref _logDirectory, "logs");
+                CreateAppDirectory(ref _logDirectory, LogDirectoryName);
                 return _logDirectory!;
             }
         }
@@ -199,10 +202,31 @@ namespace Utilizr.Info
 
         public static void ZipLogs(string destinationFile)
         {
-            ZipLogs(destinationFile, Array.Empty<ZipLogsAdditionalItem>(), Array.Empty<ZipLogsAdditionalItem>());
+            ZipLogs(
+                destinationFile,
+                Array.Empty<ZipLogsAdditionalItem>(),
+                Array.Empty<ZipLogsAdditionalItem>()
+            );
         }
 
-        public static void ZipLogs(string destinationFile, ZipLogsAdditionalItem[] additionalDirs, ZipLogsAdditionalItem[] additionalFiles) 
+        public static void ZipLogs(
+            string destinationFile,
+            ZipLogsAdditionalItem[] additionalDirs,
+            ZipLogsAdditionalItem[] additionalFiles)
+        {
+            var logDir = new ZipLogsAdditionalItem { Path = LogDirectory, PathInArchive = "logs" };
+            var dataDir = new ZipLogsAdditionalItem { Path = DataDirectory, PathInArchive = "data" };
+
+            ZipLogsAdditionalItem[] allDirs = [logDir, dataDir, ..additionalDirs];
+
+            ZipLogsSelective(destinationFile, allDirs, additionalFiles);
+        }
+
+
+        public static void ZipLogsSelective(
+            string destinationFile,
+            ZipLogsAdditionalItem[] directories,
+            ZipLogsAdditionalItem[] files) 
         {
             if (File.Exists(destinationFile))
             {
@@ -237,45 +261,43 @@ namespace Utilizr.Info
                     }
                 }
 
-                addFolderToZip(new ZipLogsAdditionalItem { Path = LogDirectory, PathInArchive = "logs" });
-                addFolderToZip(new ZipLogsAdditionalItem { Path = DataDirectory, PathInArchive = "data" });
-
-                foreach (var additionalDirectory in additionalDirs)
+                foreach (var directory in directories)
                 {
                     try
                     {
-                        if (!Directory.Exists(additionalDirectory.Path))
+                        if (!Directory.Exists(directory.Path))
                             continue;
 
-                        addFolderToZip(additionalDirectory);
+                        addFolderToZip(directory);
                     }
                     catch (Exception ex)
                     {
-                        System.Diagnostics.Debug.WriteLine($"Error adding additional directory '{additionalDirectory.Path}' to archive: {ex.Message}");
+                        System.Diagnostics.Debug.WriteLine($"Error adding additional directory '{directory.Path}' to archive: {ex.Message}");
                     }
                 }
 
-                foreach (var additionalFile in additionalFiles)
+                foreach (var file in files)
                 {
                     try
                     {
-                        if (!File.Exists(additionalFile.Path))
+                        if (!File.Exists(file.Path))
                             continue;
 
-                        zip.CreateEntryFromFile(additionalFile.Path, additionalFile.PathInArchive);
+                        zip.CreateEntryFromFile(file.Path, file.PathInArchive);
                     }
                     catch (Exception ex)
                     {
-                        System.Diagnostics.Debug.WriteLine($"Error adding additional file '{additionalFile.Path}' to archive: {ex.Message}");
+                        System.Diagnostics.Debug.WriteLine($"Error adding additional file '{file.Path}' to archive: {ex.Message}");
                     }
                 }
             }
         }
     }
 
+    [DebuggerDisplay("PathInArchive={PathInArchive}, Path={Path}")]
     public struct ZipLogsAdditionalItem
     {
-        public string Path;
-        public string PathInArchive;
+        public string Path { get; set; }
+        public string PathInArchive { get; set; }
     }
 }

--- a/Utilizr/Info/AppInfo.cs
+++ b/Utilizr/Info/AppInfo.cs
@@ -162,7 +162,7 @@ namespace Utilizr.Info
         }
 
 #if WINDOWS
-        private static string GetAppDirectory(string dirName, AppInfoRoot rootDir)
+        public static string GetAppDirectory(string dirName, AppInfoRoot rootDir)
         {
             if (string.IsNullOrEmpty(AppName))
                 throw new InvalidOperationException($"Unable to get window's directory with null/empty '{nameof(AppName)}' for '{dirName}' with root '{rootDir}'");


### PR DESCRIPTION
- Support for `%localappdata%` via `SHGetKnownFolderPath`, overloaded to allow passing in a specific user's token.
    - Includes a fix where `SHGetKnownFolderPath` wasn't freed via `FreeCoTaskMem`.
- New `AppInfo.ZipLogsSelective()` to support a custom `ZipLogsAdditionalItem` selection, with the original `ZipLogs()` passing their default values into this new function.
- Added optional `GetHeadersForRequestLogging()` override to allow masking of sensitive request headers.